### PR TITLE
Refactor/api changes

### DIFF
--- a/impy/__init__.py
+++ b/impy/__init__.py
@@ -30,3 +30,8 @@ impy_config['epos']['datdir'] = join(base_path, impy_config['epos']['datdir'])
 pdata = PYTHIAParticleData(
     cache_file=open(
         join(base_path, impy_config["pdata_cachefile"]), 'wb'))
+
+
+import impy.models as models
+import impy.kinematics as kinematics
+import impy.constants as constants

--- a/impy/common.py
+++ b/impy/common.py
@@ -335,6 +335,11 @@ class MCRun(six.with_metaclass(ABCMeta)):
 
         # FORTRAN LUN that keeps logfile handle
         self.output_lun = None
+        
+        # Number of events to generate
+        self.nevents = None
+        # Normalization 1/nevents for histograms
+        self.norm = None
 
     def __enter__(self):
         """TEMP: It would be good to actually use the with construct to
@@ -552,6 +557,8 @@ class MCRun(six.with_metaclass(ABCMeta)):
         # Initialize counters to prevent infinite loops in rejections
         ntrials = 0
         nremaining = nevents
+        self.nevents = nevents
+        self.norm = 1./float(nevents)
         while nremaining > 0:
             if self.generate_event() == 0:
                 yield self._event_class(self.lib, self._curr_event_kin,

--- a/impy/common.py
+++ b/impy/common.py
@@ -404,6 +404,14 @@ class MCRun(six.with_metaclass(ABCMeta)):
         """
         pass
 
+    @property
+    def event_kinematics(self):
+        return self._curr_event_kin
+    
+    @event_kinematics.setter
+    def event_kinematics(self, evtkin):
+        self.set_event_kinematics(evtkin)
+
     @abstractmethod
     def set_stable(self, pdgid, stable=True):
         """Prevent decay of unstable particles

--- a/impy/constants.py
+++ b/impy/constants.py
@@ -1,10 +1,10 @@
 # This dependency might be overkill for just reading a few
 # variables. Should be changed at some point.
-import scipy.constants as spc
+from scipy.constants import speed_of_light as _c_SI
 
-c = 1e2 * spc.c
-cm2sec = 1e-2 / spc.c
-sec2cm = spc.c * 1e2
+c = 1e2 * _c_SI
+cm2sec = 1e-2 / _c_SI
+sec2cm = _c_SI * 1e2
 eV = 1e-9
 keV = 1e-6
 MeV = 1e-3

--- a/impy/models/__init__.py
+++ b/impy/models/__init__.py
@@ -1,0 +1,10 @@
+from impy.models.sophia import Sophia20
+from impy.models.sibyll import Sibyll21, Sibyll23, Sibyll23c, Sibyll23c00, Sibyll23c01,\
+    Sibyll23c02, Sibyll23c03, Sibyll23c04, Sibyll23d
+from impy.models.dpmjetIII import DpmjetIII191, DpmjetIII192, DpmjetIII306
+from impy.models.epos import EposLHC
+from impy.models.phojet import Phojet112, Phojet191
+from impy.models.urqmd import UrQMD34
+from impy.models.qgsjet import QGSJet01c, QGSJetII03, QGSJetII04
+from impy.models.pythia6 import Pyphia6
+from impy.models.pythia8 import Pyphia8

--- a/impy/models/dpmjetII.py
+++ b/impy/models/dpmjetII.py
@@ -54,7 +54,7 @@ class DpmjetIIMCRun(MCRun):
         k = self.evkin
         return self.lib.siinel(self.lib.mcihad(k.p1pdg), 1, k.ecm)
 
-    def set_event_kinematics(self, event_kinematics):
+    def _set_event_kinematics(self, event_kinematics):
         k = event_kinematics
 
         self.dpmevt_tup = k.elab, k.A1, k.Z1, k.A2, k.Z2, \
@@ -64,7 +64,7 @@ class DpmjetIIMCRun(MCRun):
 
     def init_generator(self, config):
         # Comprise DPMJET input from the event kinematics object
-        self.set_event_kinematics(self.evkin)
+        self._set_event_kinematics(self.evkin)
         k = self.evkin
 
         try:

--- a/impy/models/dpmjetII.py
+++ b/impy/models/dpmjetII.py
@@ -24,6 +24,8 @@ class DpmjetIIMCEvent(MCEvent):
 
         if 'charge_info' in event_config and event_config['charge_info']:
             self.charge = lib.extevt.idch[sel]
+            # This is a patch to allow working with all other generators
+            self._charge_init = self.charge
 
         self.p_ids = evt.idhkk[sel]
         self.pt2 = evt.phkk[0, sel]**2 + evt.phkk[1, sel]**2

--- a/impy/models/dpmjetIII.py
+++ b/impy/models/dpmjetIII.py
@@ -272,3 +272,25 @@ class DpmjetIIIRun(MCRun):
         reject = self.lib.dt_kkinc(*self._dpmjet_tup(), kkmat=-1)
         self.lib.dtevno.nevent += 1
         return reject
+
+class DpmjetIII191(DpmjetIIIRun):
+    def __init__(self, event_kinematics, seed="random", logfname=None):
+        from impy.definitions import interaction_model_by_tag as models_dict
+        interaction_model_def = models_dict["DPMJETIII191"]       
+        super(DpmjetIIIRun, self).__init__(interaction_model_def)
+        self.init_generator(event_kinematics, seed, logfname)
+        
+class DpmjetIII192(DpmjetIIIRun):
+    def __init__(self, event_kinematics, seed="random", logfname=None):
+        from impy.definitions import interaction_model_by_tag as models_dict
+        interaction_model_def = models_dict["DPMJETIII192"]       
+        super(DpmjetIIIRun, self).__init__(interaction_model_def)
+        self.init_generator(event_kinematics, seed, logfname)
+
+class DpmjetIII306(DpmjetIIIRun):
+    def __init__(self, event_kinematics, seed="random", logfname=None):
+        from impy.definitions import interaction_model_by_tag as models_dict
+        interaction_model_def = models_dict["DPMJETIII306"]       
+        super(DpmjetIIIRun, self).__init__(interaction_model_def)
+        self.init_generator(event_kinematics, seed, logfname)                
+    

--- a/impy/models/dpmjetIII.py
+++ b/impy/models/dpmjetIII.py
@@ -58,7 +58,7 @@ class DpmjetIIIEvent(MCEvent):
         return self.lib.dtevt1.jdahkk
 
     @property
-    def charge(self):
+    def _charge_init(self):
         return self.lib.dtpart.iich[self.lib.dtevt2.idbam[self.selection] - 1]
 
     # Nuclear collision parameters

--- a/impy/models/dpmjetIII.py
+++ b/impy/models/dpmjetIII.py
@@ -127,7 +127,7 @@ class DpmjetIIIRun(MCRun):
              (k.A1, k.Z1, k.A2, k.Z2, self.lib.idt_icihad(k.p1pdg), k.elab))
         return (k.A1, k.Z1, k.A2, k.Z2, self.lib.idt_icihad(k.p1pdg), k.elab)
 
-    def set_event_kinematics(self, event_kinematics):
+    def _set_event_kinematics(self, event_kinematics):
         """Set new combination of energy, momentum, projectile
         and target combination for next event."""
         info(5, 'Setting event kinematics')
@@ -141,7 +141,7 @@ class DpmjetIIIRun(MCRun):
 
         # AF: No idea yet, but apparently this functionality was around?!
         # if hasattr(k, 'beam') and hasattr(self.lib, 'init'):
-        #     print(self.class_name + "::set_event_kinematics():" +
+        #     print(self.class_name + "::_set_event_kinematics():" +
         #           "setting beam params", k.beam)
         #     self.lib.dt_setbm(k.A1, k.Z1, k.A2, k.Z2, k.beam[0], k.beam[1])
         #     print 'OK'
@@ -185,7 +185,7 @@ class DpmjetIIIRun(MCRun):
         self._max_A1 = event_kinematics.A1
         self._max_A2 = event_kinematics.A2
 
-        self.set_event_kinematics(event_kinematics)
+        self._set_event_kinematics(event_kinematics)
         k = self._curr_event_kin
         dpm_conf = impy_config['dpmjetIII']
 
@@ -277,20 +277,20 @@ class DpmjetIII191(DpmjetIIIRun):
     def __init__(self, event_kinematics, seed="random", logfname=None):
         from impy.definitions import interaction_model_by_tag as models_dict
         interaction_model_def = models_dict["DPMJETIII191"]       
-        super(DpmjetIIIRun, self).__init__(interaction_model_def)
+        super().__init__(interaction_model_def)
         self.init_generator(event_kinematics, seed, logfname)
         
 class DpmjetIII192(DpmjetIIIRun):
     def __init__(self, event_kinematics, seed="random", logfname=None):
         from impy.definitions import interaction_model_by_tag as models_dict
         interaction_model_def = models_dict["DPMJETIII192"]       
-        super(DpmjetIIIRun, self).__init__(interaction_model_def)
+        super().__init__(interaction_model_def)
         self.init_generator(event_kinematics, seed, logfname)
 
 class DpmjetIII306(DpmjetIIIRun):
     def __init__(self, event_kinematics, seed="random", logfname=None):
         from impy.definitions import interaction_model_by_tag as models_dict
         interaction_model_def = models_dict["DPMJETIII306"]       
-        super(DpmjetIIIRun, self).__init__(interaction_model_def)
+        super().__init__(interaction_model_def)
         self.init_generator(event_kinematics, seed, logfname)                
     

--- a/impy/models/epos.py
+++ b/impy/models/epos.py
@@ -182,3 +182,10 @@ class EPOSRun(MCRun):
         self.lib.afinal()
         self.lib.hepmcstore()
         return False
+
+class EposLHC(EPOSRun):
+    def __init__(self, event_kinematics, seed="random", logfname=None):
+        from impy.definitions import interaction_model_by_tag as models_dict
+        interaction_model_def = models_dict["EPOSLHC"]       
+        super(EPOSRun, self).__init__(interaction_model_def)
+        self.init_generator(event_kinematics, seed, logfname)

--- a/impy/models/epos.py
+++ b/impy/models/epos.py
@@ -60,7 +60,7 @@ class EPOSEvent(MCEvent):
         return self.lib.hepevt.jdahep
 
     @property
-    def charge(self):
+    def _charge_init(self):
         return self.lib.charge_vect(self.lib.hepevt.idhep[self.selection])
 
     # Nuclear collision parameters

--- a/impy/models/epos.py
+++ b/impy/models/epos.py
@@ -113,7 +113,7 @@ class EPOSRun(MCRun):
              (k.ecm, -1., k.p1pdg, k.p2pdg, k.A1, k.Z1, k.A2, k.Z2))
         return (k.ecm, -1., k.p1pdg, k.p2pdg, k.A1, k.Z1, k.A2, k.Z2)
 
-    def set_event_kinematics(self, event_kinematics):
+    def _set_event_kinematics(self, event_kinematics):
         """Set new combination of energy, momentum, projectile
         and target combination for next event."""
         k = event_kinematics
@@ -165,7 +165,7 @@ class EPOSRun(MCRun):
 
         # Set default stable
         self._define_default_fs_particles()
-        self.set_event_kinematics(event_kinematics)
+        self._set_event_kinematics(event_kinematics)
 
         self.lib.charge_vect = np.vectorize(self.lib.getcharge, otypes=[np.int])
 
@@ -187,5 +187,5 @@ class EposLHC(EPOSRun):
     def __init__(self, event_kinematics, seed="random", logfname=None):
         from impy.definitions import interaction_model_by_tag as models_dict
         interaction_model_def = models_dict["EPOSLHC"]       
-        super(EPOSRun, self).__init__(interaction_model_def)
+        super().__init__(interaction_model_def)
         self.init_generator(event_kinematics, seed, logfname)

--- a/impy/models/phojet.py
+++ b/impy/models/phojet.py
@@ -49,7 +49,7 @@ class PhojetEvent(MCEvent):
         self._apply_slicing()
 
     @property
-    def charge(self):
+    def _charge_init(self):
         return self.lib.poevt2.icolor[0, self.selection] // 3
 
     def _gen_cut_info(self):

--- a/impy/models/phojet.py
+++ b/impy/models/phojet.py
@@ -141,7 +141,7 @@ class PHOJETRun(MCRun):
             self.lib.pydat3.mdcy[kc - 1, 0] = 1
             info(5, 'forcing decay of', pdgid)
 
-    def set_event_kinematics(self, event_kinematics):
+    def _set_event_kinematics(self, event_kinematics):
         """Set new combination of energy, momentum, projectile
         and target combination for next event."""
         info(5, 'Setting event kinematics')
@@ -240,7 +240,7 @@ class PHOJETRun(MCRun):
         # direct photon interaction (for incoming photons only)
         process_switch[7, 0] = 1
 
-        self.set_event_kinematics(event_kinematics)
+        self._set_event_kinematics(event_kinematics)
 
         if self.lib.pho_event(-1, self.p1, self.p2)[1]:
             raise Exception('PHOJET failed to initialize with the current',
@@ -272,12 +272,12 @@ class Phojet112(PHOJETRun):
     def __init__(self, event_kinematics, seed="random", logfname=None):
         from impy.definitions import interaction_model_by_tag as models_dict
         interaction_model_def = models_dict["PHOJET112"]       
-        super(PHOJETRun, self).__init__(interaction_model_def)
+        super().__init__(interaction_model_def)
         self.init_generator(event_kinematics, seed, logfname)
         
 class Phojet191(PHOJETRun):
     def __init__(self, event_kinematics, seed="random", logfname=None):
         from impy.definitions import interaction_model_by_tag as models_dict
         interaction_model_def = models_dict["PHOJET191"]       
-        super(PHOJETRun, self).__init__(interaction_model_def)
+        super().__init__(interaction_model_def)
         self.init_generator(event_kinematics, seed, logfname)        

--- a/impy/models/phojet.py
+++ b/impy/models/phojet.py
@@ -267,3 +267,17 @@ class PHOJETRun(MCRun):
 
     def generate_event(self):
         return self.lib.pho_event(1, self.p1, self.p2)[1]
+
+class Phojet112(PHOJETRun):
+    def __init__(self, event_kinematics, seed="random", logfname=None):
+        from impy.definitions import interaction_model_by_tag as models_dict
+        interaction_model_def = models_dict["PHOJET112"]       
+        super(PHOJETRun, self).__init__(interaction_model_def)
+        self.init_generator(event_kinematics, seed, logfname)
+        
+class Phojet191(PHOJETRun):
+    def __init__(self, event_kinematics, seed="random", logfname=None):
+        from impy.definitions import interaction_model_by_tag as models_dict
+        interaction_model_def = models_dict["PHOJET191"]       
+        super(PHOJETRun, self).__init__(interaction_model_def)
+        self.init_generator(event_kinematics, seed, logfname)        

--- a/impy/models/pythia6.py
+++ b/impy/models/pythia6.py
@@ -157,3 +157,11 @@ class PYTHIA6Run(MCRun):
     def generate_event(self):
         self.event_call()
         return False
+    
+class Pyphia6(PYTHIA6Run):
+    def __init__(self, event_kinematics, seed="random", logfname=None):
+        from impy.definitions import interaction_model_by_tag as models_dict
+        interaction_model_def = models_dict["PYTHIA6"]       
+        super(PYTHIA6Run, self).__init__(interaction_model_def)
+        self.init_generator(event_kinematics, seed, logfname)     
+          

--- a/impy/models/pythia6.py
+++ b/impy/models/pythia6.py
@@ -84,7 +84,7 @@ class PYTHIA6Run(MCRun):
         """PYTHIA6 does not support nuclear targets."""
         raise Exception("PYTHIA6 does not support nuclear targets.")
 
-    def set_event_kinematics(self, event_kinematics):
+    def _set_event_kinematics(self, event_kinematics):
         """Set new combination of energy, momentum, projectile
         and target combination for next event."""
         k = event_kinematics
@@ -134,7 +134,7 @@ class PYTHIA6Run(MCRun):
         # self.mstp[51]
 
         # self.lib.pysubs.msel = 2
-        # self.set_event_kinematics(event_kinematics)
+        # self._set_event_kinematics(event_kinematics)
 
         # Set default stable
         self._define_default_fs_particles()
@@ -162,6 +162,6 @@ class Pyphia6(PYTHIA6Run):
     def __init__(self, event_kinematics, seed="random", logfname=None):
         from impy.definitions import interaction_model_by_tag as models_dict
         interaction_model_def = models_dict["PYTHIA6"]       
-        super(PYTHIA6Run, self).__init__(interaction_model_def)
+        super().__init__(interaction_model_def)
         self.init_generator(event_kinematics, seed, logfname)     
           

--- a/impy/models/pythia6.py
+++ b/impy/models/pythia6.py
@@ -62,7 +62,7 @@ class PYTHIA6Event(MCEvent):
         return self.lib.hepevt.jdahep
 
     @property
-    def charge(self):
+    def _charge_init(self):
         if self.charge_vec is None:
             self.charge_vec = [
                 self.lib.pychge(self.lib.pyjets.k[i, 1]) / 3

--- a/impy/models/pythia8.py
+++ b/impy/models/pythia8.py
@@ -271,3 +271,10 @@ class PYTHIA8Run(MCRun):
 
     def generate_event(self):
         return not self.lib.next()
+
+class Pyphia8(PYTHIA8Run):
+    def __init__(self, event_kinematics, seed="random", logfname=None):
+        from impy.definitions import interaction_model_by_tag as models_dict
+        interaction_model_def = models_dict["PYTHIA8"]       
+        super(PYTHIA8Run, self).__init__(interaction_model_def)
+        self.init_generator(event_kinematics, seed, logfname) 

--- a/impy/models/pythia8.py
+++ b/impy/models/pythia8.py
@@ -115,7 +115,7 @@ class PYTHIA8Run(MCRun):
         # Cross section and energy (in mb and GeV)
         return self.lib.info.sigmaGen()
 
-    def set_event_kinematics(self, event_kinematics):
+    def _set_event_kinematics(self, event_kinematics):
         """Set new combination of energy, momentum, projectile
         and target combination for next event."""
         k = event_kinematics
@@ -256,7 +256,7 @@ class PYTHIA8Run(MCRun):
         # since changing energy changes resets the stable settings
         self.stable_history = {}
 
-        # self.set_event_kinematics(event_kinematics)
+        # self._set_event_kinematics(event_kinematics)
 
     def set_stable(self, pdgid, stable=True):
         
@@ -276,5 +276,5 @@ class Pyphia8(PYTHIA8Run):
     def __init__(self, event_kinematics, seed="random", logfname=None):
         from impy.definitions import interaction_model_by_tag as models_dict
         interaction_model_def = models_dict["PYTHIA8"]       
-        super(PYTHIA8Run, self).__init__(interaction_model_def)
+        super().__init__(interaction_model_def)
         self.init_generator(event_kinematics, seed, logfname) 

--- a/impy/models/pythia8.py
+++ b/impy/models/pythia8.py
@@ -81,7 +81,7 @@ class PYTHIA8Event(MCEvent):
         return self.lib.hepevt.jdahep
 
     @property
-    def charge(self):
+    def _charge_init(self):
         return self.p_charge[self.selection]
 
     # Nuclear collision parameters

--- a/impy/models/qgsjet.py
+++ b/impy/models/qgsjet.py
@@ -297,3 +297,25 @@ class QGSJet01Run(MCRun):
         # Convert QGSJET to HEPEVT
         self.lib.chepevt()
         return False
+    
+class QGSJet01c(QGSJet01Run):
+    def __init__(self, event_kinematics, seed="random", logfname=None):
+        from impy.definitions import interaction_model_by_tag as models_dict
+        interaction_model_def = models_dict["QGSJET01C"]       
+        super(QGSJet01Run, self).__init__(interaction_model_def)
+        self.init_generator(event_kinematics, seed, logfname) 
+      
+class QGSJetII03(QGSJetIIRun):
+    def __init__(self, event_kinematics, seed="random", logfname=None):
+        from impy.definitions import interaction_model_by_tag as models_dict
+        interaction_model_def = models_dict["QGSJETII03"]       
+        super(QGSJetIIRun, self).__init__(interaction_model_def)
+        self.init_generator(event_kinematics, seed, logfname) 
+        
+class QGSJetII04(QGSJetIIRun):   
+    def __init__(self, event_kinematics, seed="random", logfname=None):
+        from impy.definitions import interaction_model_by_tag as models_dict
+        interaction_model_def = models_dict["QGSJETII04"]       
+        super(QGSJetIIRun, self).__init__(interaction_model_def)
+        self.init_generator(event_kinematics, seed, logfname)           
+       

--- a/impy/models/qgsjet.py
+++ b/impy/models/qgsjet.py
@@ -58,7 +58,7 @@ class QGSJETEvent(MCEvent):
         return self.lib.hepevt.jdahep
 
     @property
-    def charge(self):
+    def _charge_init(self):
         return self.lib.qgchg.ichg[self.selection]
 
     @property

--- a/impy/models/qgsjet.py
+++ b/impy/models/qgsjet.py
@@ -130,7 +130,7 @@ class QGSJetIIRun(MCRun):
                                _qgsjet_hadron_classes[abs(k.p1pdg)], k.A1,
                                k.A2)
 
-    def set_event_kinematics(self, event_kinematics):
+    def _set_event_kinematics(self, event_kinematics):
         """Set new combination of energy, momentum, projectile
         and target for next event."""
 
@@ -180,7 +180,7 @@ class QGSJetIIRun(MCRun):
 
         # Set default stable
         info(10, 'All particles stable in QGSJET-II')
-        self.set_event_kinematics(event_kinematics)
+        self._set_event_kinematics(event_kinematics)
 
     def set_stable(self, pdgid, stable=True):
         info(10, "All particles stable in QGSJet-II.")
@@ -236,7 +236,7 @@ class QGSJet01Run(MCRun):
 
         return np.exp(spl(np.log(self._curr_event_kin.elab)))
 
-    def set_event_kinematics(self, event_kinematics):
+    def _set_event_kinematics(self, event_kinematics):
         """Set new combination of energy, momentum, projectile
         and target combination for next event."""
 
@@ -287,7 +287,7 @@ class QGSJet01Run(MCRun):
 
         # Set default stable
         info(10, 'All particles stable in QGSJET-01')
-        self.set_event_kinematics(event_kinematics)
+        self._set_event_kinematics(event_kinematics)
 
     def set_stable(self, pdgid, stable=True):
         info(10, "All particles stable in QGSJet.")
@@ -302,20 +302,20 @@ class QGSJet01c(QGSJet01Run):
     def __init__(self, event_kinematics, seed="random", logfname=None):
         from impy.definitions import interaction_model_by_tag as models_dict
         interaction_model_def = models_dict["QGSJET01C"]       
-        super(QGSJet01Run, self).__init__(interaction_model_def)
+        super().__init__(interaction_model_def)
         self.init_generator(event_kinematics, seed, logfname) 
       
 class QGSJetII03(QGSJetIIRun):
     def __init__(self, event_kinematics, seed="random", logfname=None):
         from impy.definitions import interaction_model_by_tag as models_dict
         interaction_model_def = models_dict["QGSJETII03"]       
-        super(QGSJetIIRun, self).__init__(interaction_model_def)
+        super().__init__(interaction_model_def)
         self.init_generator(event_kinematics, seed, logfname) 
         
 class QGSJetII04(QGSJetIIRun):   
     def __init__(self, event_kinematics, seed="random", logfname=None):
         from impy.definitions import interaction_model_by_tag as models_dict
         interaction_model_def = models_dict["QGSJETII04"]       
-        super(QGSJetIIRun, self).__init__(interaction_model_def)
+        super().__init__(interaction_model_def)
         self.init_generator(event_kinematics, seed, logfname)           
        

--- a/impy/models/sibyll.py
+++ b/impy/models/sibyll.py
@@ -139,7 +139,7 @@ class SIBYLLRun(MCRun):
         else:
             return sigma[0]
 
-    def set_event_kinematics(self, event_kinematics):
+    def _set_event_kinematics(self, event_kinematics):
         """Set new combination of energy, momentum, projectile
         and target combination for next event."""
 
@@ -180,7 +180,7 @@ class SIBYLLRun(MCRun):
 
         self.lib.s_debug.ndebug = impy_config['sibyll']['debug_level']
 
-        self.set_event_kinematics(event_kinematics)
+        self._set_event_kinematics(event_kinematics)
         self.attach_log(fname=logfname)
         self.lib.sibini(int(seed))
         self.lib.pdg_ini()
@@ -215,62 +215,62 @@ class Sibyll21(SIBYLLRun):
     def __init__(self, event_kinematics, seed="random", logfname=None):
         from impy.definitions import interaction_model_by_tag as models_dict
         interaction_model_def = models_dict["SIBYLL21"]       
-        super(SIBYLLRun, self).__init__(interaction_model_def)
+        super().__init__(interaction_model_def)
         self.init_generator(event_kinematics, seed, logfname)
         
 class Sibyll23(SIBYLLRun):
     def __init__(self, event_kinematics, seed="random", logfname=None):
         from impy.definitions import interaction_model_by_tag as models_dict
         interaction_model_def = models_dict["SIBYLL23"]       
-        super(SIBYLLRun, self).__init__(interaction_model_def)
+        super().__init__(interaction_model_def)
         self.init_generator(event_kinematics, seed, logfname)
         
 class Sibyll23c(SIBYLLRun):
     def __init__(self, event_kinematics, seed="random", logfname=None):
         from impy.definitions import interaction_model_by_tag as models_dict
         interaction_model_def = models_dict["SIBYLL23C"]       
-        super(SIBYLLRun, self).__init__(interaction_model_def)
+        super().__init__(interaction_model_def)
         self.init_generator(event_kinematics, seed, logfname)
 
 class Sibyll23c00(SIBYLLRun):
     def __init__(self, event_kinematics, seed="random", logfname=None):
         from impy.definitions import interaction_model_by_tag as models_dict
         interaction_model_def = models_dict["SIBYLL23C00"]       
-        super(SIBYLLRun, self).__init__(interaction_model_def)
+        super().__init__(interaction_model_def)
         self.init_generator(event_kinematics, seed, logfname)    
         
 class Sibyll23c01(SIBYLLRun):
     def __init__(self, event_kinematics, seed="random", logfname=None):
         from impy.definitions import interaction_model_by_tag as models_dict
         interaction_model_def = models_dict["SIBYLL23C01"]       
-        super(SIBYLLRun, self).__init__(interaction_model_def)
+        super().__init__(interaction_model_def)
         self.init_generator(event_kinematics, seed, logfname)
 
 class Sibyll23c02(SIBYLLRun):
     def __init__(self, event_kinematics, seed="random", logfname=None):
         from impy.definitions import interaction_model_by_tag as models_dict
         interaction_model_def = models_dict["SIBYLL23C02"]       
-        super(SIBYLLRun, self).__init__(interaction_model_def)
+        super().__init__(interaction_model_def)
         self.init_generator(event_kinematics, seed, logfname)
 
 class Sibyll23c03(SIBYLLRun):
     def __init__(self, event_kinematics, seed="random", logfname=None):
         from impy.definitions import interaction_model_by_tag as models_dict
         interaction_model_def = models_dict["SIBYLL23C03"]       
-        super(SIBYLLRun, self).__init__(interaction_model_def)
+        super().__init__(interaction_model_def)
         self.init_generator(event_kinematics, seed, logfname)
         
 class Sibyll23c04(SIBYLLRun):
     def __init__(self, event_kinematics, seed="random", logfname=None):
         from impy.definitions import interaction_model_by_tag as models_dict
         interaction_model_def = models_dict["SIBYLL23C04"]       
-        super(SIBYLLRun, self).__init__(interaction_model_def)
+        super().__init__(interaction_model_def)
         self.init_generator(event_kinematics, seed, logfname)
 
 class Sibyll23d(SIBYLLRun):
     def __init__(self, event_kinematics, seed="random", logfname=None):
         from impy.definitions import interaction_model_by_tag as models_dict
         interaction_model_def = models_dict["SIBYLL23D"]       
-        super(SIBYLLRun, self).__init__(interaction_model_def)
+        super().__init__(interaction_model_def)
         self.init_generator(event_kinematics, seed, logfname)                                               
                   

--- a/impy/models/sibyll.py
+++ b/impy/models/sibyll.py
@@ -51,7 +51,7 @@ class SibyllEvent(MCEvent):
         self._apply_slicing()
     
     @property
-    def charge(self):
+    def _charge_init(self):
         return self.lib.schg.ichg[self.selection]
 
     @property

--- a/impy/models/sibyll.py
+++ b/impy/models/sibyll.py
@@ -210,3 +210,67 @@ class SIBYLLRun(MCRun):
         self.lib.decsib()
         self.conv_hepevt()
         return 0  # SIBYLL never rejects
+
+class Sibyll21(SIBYLLRun):
+    def __init__(self, event_kinematics, seed="random", logfname=None):
+        from impy.definitions import interaction_model_by_tag as models_dict
+        interaction_model_def = models_dict["SIBYLL21"]       
+        super(SIBYLLRun, self).__init__(interaction_model_def)
+        self.init_generator(event_kinematics, seed, logfname)
+        
+class Sibyll23(SIBYLLRun):
+    def __init__(self, event_kinematics, seed="random", logfname=None):
+        from impy.definitions import interaction_model_by_tag as models_dict
+        interaction_model_def = models_dict["SIBYLL23"]       
+        super(SIBYLLRun, self).__init__(interaction_model_def)
+        self.init_generator(event_kinematics, seed, logfname)
+        
+class Sibyll23c(SIBYLLRun):
+    def __init__(self, event_kinematics, seed="random", logfname=None):
+        from impy.definitions import interaction_model_by_tag as models_dict
+        interaction_model_def = models_dict["SIBYLL23C"]       
+        super(SIBYLLRun, self).__init__(interaction_model_def)
+        self.init_generator(event_kinematics, seed, logfname)
+
+class Sibyll23c00(SIBYLLRun):
+    def __init__(self, event_kinematics, seed="random", logfname=None):
+        from impy.definitions import interaction_model_by_tag as models_dict
+        interaction_model_def = models_dict["SIBYLL23C00"]       
+        super(SIBYLLRun, self).__init__(interaction_model_def)
+        self.init_generator(event_kinematics, seed, logfname)    
+        
+class Sibyll23c01(SIBYLLRun):
+    def __init__(self, event_kinematics, seed="random", logfname=None):
+        from impy.definitions import interaction_model_by_tag as models_dict
+        interaction_model_def = models_dict["SIBYLL23C01"]       
+        super(SIBYLLRun, self).__init__(interaction_model_def)
+        self.init_generator(event_kinematics, seed, logfname)
+
+class Sibyll23c02(SIBYLLRun):
+    def __init__(self, event_kinematics, seed="random", logfname=None):
+        from impy.definitions import interaction_model_by_tag as models_dict
+        interaction_model_def = models_dict["SIBYLL23C02"]       
+        super(SIBYLLRun, self).__init__(interaction_model_def)
+        self.init_generator(event_kinematics, seed, logfname)
+
+class Sibyll23c03(SIBYLLRun):
+    def __init__(self, event_kinematics, seed="random", logfname=None):
+        from impy.definitions import interaction_model_by_tag as models_dict
+        interaction_model_def = models_dict["SIBYLL23C03"]       
+        super(SIBYLLRun, self).__init__(interaction_model_def)
+        self.init_generator(event_kinematics, seed, logfname)
+        
+class Sibyll23c04(SIBYLLRun):
+    def __init__(self, event_kinematics, seed="random", logfname=None):
+        from impy.definitions import interaction_model_by_tag as models_dict
+        interaction_model_def = models_dict["SIBYLL23C04"]       
+        super(SIBYLLRun, self).__init__(interaction_model_def)
+        self.init_generator(event_kinematics, seed, logfname)
+
+class Sibyll23d(SIBYLLRun):
+    def __init__(self, event_kinematics, seed="random", logfname=None):
+        from impy.definitions import interaction_model_by_tag as models_dict
+        interaction_model_def = models_dict["SIBYLL23D"]       
+        super(SIBYLLRun, self).__init__(interaction_model_def)
+        self.init_generator(event_kinematics, seed, logfname)                                               
+                  

--- a/impy/models/sophia.py
+++ b/impy/models/sophia.py
@@ -23,37 +23,32 @@ class SophiaEvent(MCEvent):
     """Wrapper class around Sophia code"""
 
     def __init__(self, lib, event_kinematics, event_frame):
+        evt = lib.hepevt
 
-        # prepare hepevt common block
-        lib.toevt()
-        # number of particles in event
-        np = lib.hepevt.nhep
-        # array of particle momenta
-        pem_arr = lib.hepevt.phep[:, 0:np]
-        # array of verticies (x, y, z, t) - all zeros for sophia
-        vt_arr = lib.hepevt.vhep[:, 0:np]
+        # Save selector for implementation of on-demand properties
+        px, py, pz, en, m = evt.phep
+        # verticies (x, y, z, t) - all zeros for sophia
+        vx, vy, vz, vt = evt.vhep
         
-        MCEvent.__init__(
-            self,
-            lib=lib,
-            event_kinematics=event_kinematics,
-            event_frame=event_frame,
-            nevent=lib.hepevt.nevhep,  # event number
-            npart=np,
-            p_ids=lib.hepevt.idhep[0:np],
-            status=lib.hepevt.isthep[0:np],
-            px=pem_arr[0],
-            py=pem_arr[1],
-            pz=pem_arr[2],
-            en=pem_arr[3],
-            m=pem_arr[4],
-            vx=vt_arr[0],
-            vy=vt_arr[1],
-            vz=vt_arr[2],
-            vt=vt_arr[3],
-            pem_arr=pem_arr,
-            vt_arr=vt_arr,
-        )
+        MCEvent.__init__(self,
+                         lib=lib,
+                         event_kinematics=event_kinematics,
+                         event_frame=event_frame,
+                         nevent=evt.nevhep,
+                         npart=evt.nhep,
+                         p_ids=evt.idhep,
+                         status=evt.isthep,
+                         px=px,
+                         py=py,
+                         pz=pz,
+                         en=en,
+                         m=m,
+                         vx=vx,
+                         vy=vy,
+                         vz=vz,
+                         vt=vt,
+                         pem_arr=evt.phep,
+                         vt_arr=evt.vhep)
 
     def filter_final_state(self):
         self.selection = np.where(self.status == 1)
@@ -136,7 +131,7 @@ class SophiaRun(MCRun):
         event setup (energy, projectile, target)"""
         raise Exception("SophiaRun.sigma_inel_air has no implementation")
 
-    def set_event_kinematics(self, event_kinematics):
+    def _set_event_kinematics(self, event_kinematics):
         """Set new combination of energy, momentum, projectile
         and target combination for next event."""
 
@@ -192,7 +187,7 @@ class SophiaRun(MCRun):
 
         self.lib.s_plist.ideb = impy_config["sophia"]["debug_level"]
 
-        self.set_event_kinematics(event_kinematics)
+        self._set_event_kinematics(event_kinematics)
         self.attach_log(fname=logfname)
 
         self.lib.init_rmmard(int(seed))  # setting random number generator seed
@@ -239,11 +234,13 @@ class SophiaRun(MCRun):
         # pass interaction type code to MCEvent
         # via additional attribute in lib object:
         setattr(self.lib, "interaction_type_code", self.interaction_type_code)
+        # prepare hepevt common block
+        self.lib.toevt()
         return 0  # No rejection is implemented so far
 
 class Sophia20(SophiaRun):
     def __init__(self, event_kinematics, seed="random", logfname=None):
         from impy.definitions import interaction_model_by_tag as models_dict
         interaction_model_def = models_dict["SOPHIA20"]       
-        super(SophiaRun, self).__init__(interaction_model_def)
+        super().__init__(interaction_model_def)
         self.init_generator(event_kinematics, seed, logfname)

--- a/impy/models/sophia.py
+++ b/impy/models/sophia.py
@@ -240,3 +240,10 @@ class SophiaRun(MCRun):
         # via additional attribute in lib object:
         setattr(self.lib, "interaction_type_code", self.interaction_type_code)
         return 0  # No rejection is implemented so far
+
+class Sophia20(SophiaRun):
+    def __init__(self, event_kinematics, seed="random", logfname=None):
+        from impy.definitions import interaction_model_by_tag as models_dict
+        interaction_model_def = models_dict["SOPHIA20"]       
+        super(SophiaRun, self).__init__(interaction_model_def)
+        self.init_generator(event_kinematics, seed, logfname)

--- a/impy/models/sophia.py
+++ b/impy/models/sophia.py
@@ -68,7 +68,7 @@ class SophiaEvent(MCEvent):
         return sophia_interaction_types[self.lib.interaction_type_code]
 
     @property
-    def charge(self):
+    def _charge_init(self):
         return self.lib.schg.ichg[self.selection]
 
     @property

--- a/impy/models/urqmd.py
+++ b/impy/models/urqmd.py
@@ -240,3 +240,10 @@ class UrQMDRun(MCRun):
         # Convert URQMD event to HEPEVT
         self.lib.chepevt()
         return 0
+
+class UrQMD34(UrQMDRun):  
+    def __init__(self, event_kinematics, seed="random", logfname=None):
+        from impy.definitions import interaction_model_by_tag as models_dict
+        interaction_model_def = models_dict["URQMD34"]       
+        super(UrQMDRun, self).__init__(interaction_model_def)
+        self.init_generator(event_kinematics, seed, logfname)

--- a/impy/models/urqmd.py
+++ b/impy/models/urqmd.py
@@ -95,7 +95,7 @@ class UrQMDRun(MCRun):
         event setup (energy, projectile, target)"""
         return self.lib.ptsigtot()
 
-    def set_event_kinematics(self, event_kinematics):
+    def _set_event_kinematics(self, event_kinematics):
         """Set new combination of energy, momentum, projectile
         and target combination for next event."""
         k = event_kinematics
@@ -179,7 +179,7 @@ class UrQMDRun(MCRun):
 
         # Set default stable
         self._define_default_fs_particles()
-        self.set_event_kinematics(event_kinematics)
+        self._set_event_kinematics(event_kinematics)
 
         self.lib.inputs.nevents = 1
         self.lib.rsys.bmin = 0
@@ -245,5 +245,5 @@ class UrQMD34(UrQMDRun):
     def __init__(self, event_kinematics, seed="random", logfname=None):
         from impy.definitions import interaction_model_by_tag as models_dict
         interaction_model_def = models_dict["URQMD34"]       
-        super(UrQMDRun, self).__init__(interaction_model_def)
+        super().__init__(interaction_model_def)
         self.init_generator(event_kinematics, seed, logfname)

--- a/impy/models/urqmd.py
+++ b/impy/models/urqmd.py
@@ -67,7 +67,7 @@ class UrQMDEvent(MCEvent):
         return self.lib.hepevt.jdahep
 
     @property
-    def charge(self):
+    def _charge_init(self):
         return self.lib.uqchg.ichg[self.selection]
 
     # Nuclear collision parameters

--- a/impy/tests/test_hepmc_writer.py
+++ b/impy/tests/test_hepmc_writer.py
@@ -43,8 +43,8 @@ def test_hepmc_writer(model_tag):
         for event in generator.event_generator(event_kinematics, 3):
             # event.filter_final_state()
             n = event.npart
-            pem = event.pem_arr.T
-            vt = event.vt_arr.T
+            pem = event._pem_arr.T
+            vt = event._vt_arr.T
             pid = event.p_ids
             status = event.status
             parents = {}

--- a/impy/writer.py
+++ b/impy/writer.py
@@ -39,8 +39,8 @@ class HepMCWriter(Writer):
         # - add info about generator
 
         self._genevent.clear()
-        pem = impy_event.pem_arr.T # the need to transpose this is bad
-        vt = impy_event.vt_arr.T # the need to transpose this is bad
+        pem = impy_event._pem_arr.T # the need to transpose this is bad
+        vt = impy_event._vt_arr.T # the need to transpose this is bad
         n = pem.shape[0]
 
         parents = impy_event.parents.T[:n]


### PR DESCRIPTION
According to the discussions in issues #3, #6, #7 and #8 the API is changed to:

```python
# Import is fixed, so autocompletion shows available submodules
import impy

ekin = impy.kinematics.EventKinematics(...)
# Event generator constructor (issue #6)
generator = impy.models.Sophia20(ekin)

# Callable generator (issue #7)
for event in generator(10000):
    # Chaining of filters
    event.filter_final().filter_charged()
    # One can "undo" last filter
    event.remove_last_filter()
    # Or completly remove all applied filters
    event.remove_all_filters()

    # One can get number of generated events (10000 in this case)
    print(generator.nevents)
    # generator.norm = 1/nevents, for example
    protons += generator.norm/widths*np.histogram(...)

    # One can change and get event_kinematics property (issue #8)
    ekin = generator.event_kinematics
    generator.event_kinematics = impy.kinematics.EventKinematics(...)
```