### PR TITLE
move to pyhepmc, removed some unused variables in setup.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+venv
 *.dSYM
 **.o
 **.so

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ I don't use a Mac and cannot debug it.
 - numpy
 - scipy
 - pyyaml
-- pyhepmc-ng
+- pyhepmc
 
 ## User interface
 

--- a/impy/tests/test_hepmc_writer.py
+++ b/impy/tests/test_hepmc_writer.py
@@ -33,7 +33,7 @@ def test_hepmc_writer(model_tag):
     # To run this test do `pytest tests/test_hepmc_writer.py`
     # This test fails because the event record written by HepMC3 C++ is bad,
     # a lot of particles are missing. Either a bug in the original impy record or a bug in the
-    # HepMC3 C++ code (not the pyhepmc_ng code).
+    # HepMC3 C++ code (not the pyhepmc code).
     generator = make_generator_instance(interaction_model_by_tag[model_tag])
     generator.init_generator(event_kinematics)
 
@@ -61,9 +61,9 @@ def test_hepmc_writer(model_tag):
             )
             w.write(event)
 
-    import pyhepmc_ng
+    import pyhepmc
 
-    for ievent, event in enumerate(pyhepmc_ng.open(test_file)):
+    for ievent, event in enumerate(pyhepmc.open(test_file)):
         assert event is not None
         assert event.event_number == ievent
 

--- a/impy/writer.py
+++ b/impy/writer.py
@@ -23,7 +23,7 @@ class Writer(object, with_metaclass(ABCMeta)):
 
 class HepMCWriter(Writer):
     def __init__(self, filename):
-        self._hep = __import__("pyhepmc_ng")  # delay import till instantiation
+        self._hep = __import__("pyhepmc")  # delay import till instantiation
         self._writer = self._hep.WriterAscii(filename)
         self._genevent = self._hep.GenEvent()
         self._event_number = 0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,3 @@
 [flake8]
 max-line-length = 90
+extend-ignore = E203, F403, E402

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,6 @@ https://github.com/pybind/cmake_example/blob/master/setup.py
 """
 
 import os
-import re
 import sys
 import platform
 import subprocess
@@ -24,15 +23,18 @@ class MakeBuild(build_ext):
     def run(self):
         if platform.system() == "Windows":
             try:
-                out = subprocess.check_output(["mingw32-make.exe", "--version"])
+                subprocess.check_output(["mingw32-make.exe", "--version"])
             except OSError:
                 raise RuntimeError(
-                    "mingw32-make.exe must be installed to build the following extensions: "
+                    (
+                        "mingw32-make.exe must be installed to "
+                        "build the following extensions: "
+                    )
                     + ", ".join(e.name for e in self.extensions)
                 )
         else:
             try:
-                out = subprocess.check_output(["make", "--version"])
+                subprocess.check_output(["make", "--version"])
             except OSError:
                 raise RuntimeError(
                     "Make must be installed to build the following extensions: "
@@ -53,7 +55,7 @@ class MakeBuild(build_ext):
             suffix = sysconfig.get_config_var("SO")
 
         if platform.system() == "Windows":
-            make_command = "mingw32-make.exe"
+            # make_command = "mingw32-make.exe"
             libext = (
                 ".cp"
                 + sysconfig.get_config_var("py_version_nodot")
@@ -67,7 +69,7 @@ class MakeBuild(build_ext):
                 "LEXT=" + libext,
             ]
         else:
-            make_command = "make"
+            # make_command = "make"
             libext = suffix
             build_args = ["LIB_DIR=" + extdir + "/impy/lib", "LEXT=" + libext]
 
@@ -132,7 +134,14 @@ setup(
     packages=["impy", "impy.models"],
     data_files=[("", ["LICENSE", "impy/impy_config.yaml"]), ("iamdata", iamfiles)],
     include_package_data=True,
-    install_requires=["six", "particletools", "numpy", "pyyaml", "pyhepmc-ng", "scipy"],
+    install_requires=[
+        "six",
+        "particletools",
+        "numpy<1.20",
+        "pyyaml",
+        "pyhepmc",
+        "scipy",
+    ],
     ext_modules=[MakeExtension("impy_libs")],
     cmdclass=dict(build_ext=MakeBuild),
     zip_safe=False,


### PR DESCRIPTION
Closes #15 

This updates from pyhepmc-ng, which was only provided as a source package, to pyhepmc, which is released as binary wheels, so the user does not have to compile anything.

I also commented out/removed a few unused variables that flake8 was complaining about in setup.py.

I checked that test_hepmc_writer.py passes, but I also noticed that 5 tests fail. I am sure that these errors are not related to my changes and therefore this should not delay merging of this PR.