### PR TITLE
Add rng_state

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -336,11 +336,11 @@ f2py_add_module(_pythia6
 f2py_add_module(_sophia
   FUNCTIONS
   eventgen print_event crossection initial
-  icon_pdg_sib init_rmmard toevt ${impy_logging}
+  icon_pdg_sib init_rmmard toevt crranma4 ${impy_logging}
   SOURCES
-  ${f2py_dir}/_sophia.pyf
-  ${f2py_dir}/_sophiamodule.c
-  ${f2py_dir}/_sophia-f2pywrappers.f
+  # ${f2py_dir}/_sophia.pyf
+  # ${f2py_dir}/_sophiamodule.c
+  # ${f2py_dir}/_sophia-f2pywrappers.f
   ${fortran_dir}/sophia/SOPHIA20.f
   ${fortran_dir}/sophia/eventgen.f
   ${fortran_dir}/sophia/sampling.f

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,93 +78,20 @@ else() # intel
 endif()
 
 ### common for all models
+set(impy_definitions IMPY)
 set(fortran_dir ${CMAKE_SOURCE_DIR}/src/fortran)
 set(f2py_dir ${CMAKE_SOURCE_DIR}/src/f2py)
 
 set(impy_logging impy_openlogfile impy_closelogfile)
 set(logging_source ${fortran_dir}/logging.f)
-set(rangen_source rangen.f)
-set(rangen_fpp_source ${fortran_dir}/rangen.fpp)
-set(rangen_sib21_source rangen_sib21.f)
-set(sibyll_init_source sibyll_init.f)
-set(sibyll_init_sib21_source sibyll_init_sib21.f)
-
-#
-set(sophia_jetset74dp_source jetset74dp.f)
-set(sophia_eventgen_source eventgen.f)
-set(pythia6_pythia6428_source pythia-6.4.28.f)
-set(epos_random_source epos-random.f)
-
-# WARNING this is not platform-independent and needs to be adjusted
-# when new fortran compilers should be supported
-add_custom_command(
-  OUTPUT ${rangen_source}
-  COMMAND ${CMAKE_Fortran_COMPILER}
-    -E ${fortran_dir}/rangen.fpp
-    -o ${rangen_source}
-)
-add_custom_command(
-  OUTPUT ${rangen_sib21_source}
-  COMMAND ${CMAKE_Fortran_COMPILER}
-    -E ${fortran_dir}/rangen.fpp
-    -o ${rangen_sib21_source}
-    -DSIBYLL_SP
-)
-add_custom_command(
-  OUTPUT ${sibyll_init_source}
-  COMMAND ${CMAKE_Fortran_COMPILER}
-    -E ${fortran_dir}/sibyll/sibyll_init.fpp
-    -o ${sibyll_init_source}
-    -DSIBYLL_TABLE_LENGTH=99
-)
-add_custom_command(
-  OUTPUT ${sibyll_init_sib21_source}
-  COMMAND ${CMAKE_Fortran_COMPILER}
-    -E ${fortran_dir}/sibyll/sibyll_init.fpp
-    -o ${sibyll_init_sib21_source}
-    -DSIBYLL_TABLE_LENGTH=49
-)
-
-
-add_custom_command(
-  OUTPUT ${pythia6_pythia6428_source}
-  COMMAND ${CMAKE_Fortran_COMPILER}
-    -E -cpp ${fortran_dir}/pythia6/pythia-6.4.28.f
-    -o ${pythia6_pythia6428_source}
-    -DIMPY
-)
-
-add_custom_command(
-  OUTPUT ${sophia_jetset74dp_source}
-  COMMAND ${CMAKE_Fortran_COMPILER}
-    -E -cpp ${fortran_dir}/sophia/jetset74dp.f
-    -o ${sophia_jetset74dp_source}
-    -DIMPY
-)
-
-add_custom_command(
-  OUTPUT ${sophia_eventgen_source}
-  COMMAND ${CMAKE_Fortran_COMPILER}
-    -E -cpp ${fortran_dir}/sophia/eventgen.f
-    -o ${sophia_eventgen_source}
-    -DIMPY
-)
+set(rangen_source ${fortran_dir}/rangen.fpp)
 
 
 ### eposlhc
 file(GLOB eposlhc_sources ${fortran_dir}/EPOS-LHC/sources/*.f)
 list(FILTER eposlhc_sources EXCLUDE REGEX epos_example\.f)
-# list(FILTER eposlhc_sources EXCLUDE REGEX epos-random\.f)
 
 
-add_custom_command(
-  OUTPUT ${epos_random_source}
-  COMMAND ${CMAKE_Fortran_COMPILER}
-    -E -cpp ${fortran_dir}/EPOS-LHC/sources/epos-random.f
-    -o ${epos_random_source}
-    -DIMPY
-  COMMAND cp  ${fortran_dir}/EPOS-LHC/sources/epos.inc epos.inc  
-)
 
 f2py_add_module(_eposlhc
   FUNCTIONS
@@ -188,7 +115,7 @@ f2py_add_module(_eposlhc
   INCLUDE_DIRS
   ${fortran_dir}/EPOS-LHC/sources
   COMPILE_DEFS
-  IMPY
+  ${impy_definitions}
 )
 
 
@@ -207,11 +134,13 @@ f2py_add_module(_sib21
   # ${f2py_dir}/_sib21-f2pywrappers.f
   ${fortran_dir}/sibyll/sibyll_21.f
   ${fortran_dir}/sibyll/sib21aux.f
+  ${fortran_dir}/sibyll/sibyll_init.fpp
   ${logging_source}
-  ${rangen_sib21_source}
-  ${sibyll_init_sib21_source}
+  ${rangen_source}
   COMPILE_DEFS
-  IMPY
+  ${impy_definitions}
+  SIBYLL_SP
+  SIBYLL_TABLE_LENGTH=49
 )
 
 ### sib23
@@ -223,11 +152,12 @@ f2py_add_module(_sib23
   # ${f2py_dir}/_sib23module.c
   # ${f2py_dir}/_sib23-f2pywrappers.f
   ${fortran_dir}/sibyll/sibyll2.3.f
-  ${sibyll_init_source}
+  ${fortran_dir}/sibyll/sibyll_init.fpp
   ${logging_source}
   ${rangen_source}
   COMPILE_DEFS
-  IMPY
+  ${impy_definitions}
+  SIBYLL_TABLE_LENGTH=99
 )
 
 ### sib23c00
@@ -239,11 +169,12 @@ f2py_add_module(_sib23c00
   # ${f2py_dir}/_sib23c00module.c
   # ${f2py_dir}/_sib23c00-f2pywrappers.f
   ${fortran_dir}/sibyll/sibyll2.3c00.f
-  ${sibyll_init_source}
+  ${fortran_dir}/sibyll/sibyll_init.fpp
   ${logging_source}
   ${rangen_source}
   COMPILE_DEFS
-  IMPY
+  ${impy_definitions}
+  SIBYLL_TABLE_LENGTH=99
 )
 
 ### sib23c01
@@ -255,11 +186,12 @@ f2py_add_module(_sib23c01
   # ${f2py_dir}/_sib23c01module.c
   # ${f2py_dir}/_sib23c01-f2pywrappers.f
   ${fortran_dir}/sibyll/sibyll2.3c01.f
-  ${sibyll_init_source}
+  ${fortran_dir}/sibyll/sibyll_init.fpp
   ${logging_source}
   ${rangen_source}
   COMPILE_DEFS
-  IMPY
+  ${impy_definitions}
+  SIBYLL_TABLE_LENGTH=99
 )
 
 ### sib23c02
@@ -271,11 +203,12 @@ f2py_add_module(_sib23c02
   # ${f2py_dir}/_sib23c02module.c
   # ${f2py_dir}/_sib23c02-f2pywrappers.f
   ${fortran_dir}/sibyll/sibyll2.3c02.f
-  ${sibyll_init_source}
+  ${fortran_dir}/sibyll/sibyll_init.fpp
   ${logging_source}
   ${rangen_source}
   COMPILE_DEFS
-  IMPY
+  ${impy_definitions}
+  SIBYLL_TABLE_LENGTH=99
 )
 
 ### sib23c03
@@ -287,11 +220,12 @@ f2py_add_module(_sib23c03
   # ${f2py_dir}/_sib23c03module.c
   # ${f2py_dir}/_sib23c03-f2pywrappers.f
   ${fortran_dir}/sibyll/sibyll2.3c03.f
-  ${sibyll_init_source}
+  ${fortran_dir}/sibyll/sibyll_init.fpp
   ${logging_source}
   ${rangen_source}
   COMPILE_DEFS
-  IMPY
+  ${impy_definitions}
+  SIBYLL_TABLE_LENGTH=99
 )
 
 ### sib23d
@@ -303,11 +237,12 @@ f2py_add_module(_sib23d
   # ${f2py_dir}/_sib23dmodule.c
   # ${f2py_dir}/_sib23d-f2pywrappers.f
   ${fortran_dir}/sibyll/sibyll2.3d.f
-  ${sibyll_init_source}
+  ${fortran_dir}/sibyll/sibyll_init.fpp
   ${logging_source}
   ${rangen_source}
   COMPILE_DEFS
-  IMPY
+  ${impy_definitions}
+  SIBYLL_TABLE_LENGTH=99
 )
 
 ### qgs01
@@ -324,7 +259,7 @@ f2py_add_module(_qgs01
   ${logging_source}
   ${rangen_source}
   COMPILE_DEFS
-  IMPY
+  ${impy_definitions}
 )
 
 ### qgsII03
@@ -343,7 +278,7 @@ f2py_add_module(_qgsII03
   ${logging_source}
   ${rangen_source}
   COMPILE_DEFS
-  IMPY
+  ${impy_definitions}
 )
 
 ### qgsII04
@@ -359,7 +294,7 @@ f2py_add_module(_qgsII04
   ${logging_source}
   ${rangen_source}
   COMPILE_DEFS
-  IMPY
+  ${impy_definitions}
 )
 
 ### urqmd34
@@ -392,7 +327,7 @@ f2py_add_module(_urqmd34
   # ${f2py_dir}/_urqmd34-f2pywrappers.f
   ${urqmd34_sources}
   COMPILE_DEFS
-  IMPY
+  ${impy_definitions}
 )
 # to find terms.mod ?
 target_include_directories(_urqmd34 PRIVATE ${fortran_dir}/urqmd-3.4/sources)
@@ -406,12 +341,11 @@ f2py_add_module(_pythia6
   # ${f2py_dir}/_pythia6.pyf
   # ${f2py_dir}/_pythia6module.c
   # ${f2py_dir}/_pythia6-f2pywrappers.f
-  # ${fortran_dir}/pythia6/pythia-6.4.28.f
-  ${pythia6_pythia6428_source}
+  ${fortran_dir}/pythia6/pythia-6.4.28.f
   ${logging_source}
   ${rangen_source}
   COMPILE_DEFS
-  IMPY
+  ${impy_definitions}
 )
 
 ### sophia
@@ -419,11 +353,6 @@ f2py_add_module(_sophia
   FUNCTIONS
   eventgen print_event crossection initial
   icon_pdg_sib init_rmmard toevt ${impy_logging}
-  # INTERFACE_SOURCES
-  # ${sophia_eventgen_source}
-  # ${fortran_dir}/sophia/eventgen.f
-  # ${rangen_source}
-  # ${logging_source}
   SOURCES
   # ${f2py_dir}/_sophia.pyf
   # ${f2py_dir}/_sophiamodule.c
@@ -432,30 +361,16 @@ f2py_add_module(_sophia
   ${fortran_dir}/sophia/eventgen.f
   ${fortran_dir}/sophia/sampling.f
   ${fortran_dir}/sophia/inpoutput.f
-  # ${fortran_dir}/sophia/jetset74dp.f
-  ${sophia_jetset74dp_source}
+  ${fortran_dir}/sophia/jetset74dp.f
   ${fortran_dir}/sophia/impy_sophia.f
   ${logging_source}
   ${rangen_source}
   COMPILE_DEFS
-  IMPY
+  ${impy_definitions}
 )
 
 ### dpmjet306
-
-set(dpmjet_dpmjet306f dpmjet3.0-6.f)
-
-add_custom_command(
-  OUTPUT ${dpmjet_dpmjet306f}
-  COMMAND ${CMAKE_Fortran_COMPILER}
-    -E -cpp ${fortran_dir}/dpmjet3.0-6/sources/dpmjet3.0-6.f
-    -o ${dpmjet_dpmjet306f}
-    -DIMPY
-)
-
-
 file(GLOB dpmjet306_sources ${fortran_dir}/dpmjet3.0-6/sources/*.f)
-list(FILTER dpmjet306_sources EXCLUDE REGEX dpmjet3.0-6\.f)
 
 f2py_add_module(_dpmjet306
   FUNCTIONS
@@ -472,11 +387,10 @@ f2py_add_module(_dpmjet306
   # ${f2py_dir}/_dpmjet306module.c
   # ${f2py_dir}/_dpmjet306-f2pywrappers.f
   ${dpmjet306_sources}
-  ${dpmjet_dpmjet306f}
   ${rangen_source}
   ${logging_source}
   COMPILE_DEFS
-  IMPY
+  ${impy_definitions}
 )
 
 
@@ -519,16 +433,17 @@ f2py_add_module(_dpmjetIII191
   # ${f2py_dir}/_dpmjetIII191.pyf
   # ${f2py_dir}/_dpmjetIII191module.c
   # ${f2py_dir}/_dpmjetIII191-f2pywrappers.f
-  # ${dpmjetIII191_modded_sources}
   ${dpmjetIII191_modded_sources}
-  ${rangen_fpp_source}
+  # ${dpmjetIII191_sources}
+  ${rangen_source}
   INCLUDE_DIRS
   ${fortran_dir}/dpmjetIII-19.1/include/phojet
   ${fortran_dir}/dpmjetIII-19.1/include/dpmjet
   ${fortran_dir}/dpmjetIII-19.1/include/pythia
-  ${CMAKE_CURRENT_BINARY_DIR}/include
+  ${fortran_dir}/dpmjetIII-19.1/include/flinclude
+  # ${CMAKE_CURRENT_BINARY_DIR}/include
   COMPILE_DEFS
-  IMPY
+  ${impy_definitions}
 )
 
 ### dpmjetIII193
@@ -543,7 +458,6 @@ list(FILTER dpmjetIII193_sources EXCLUDE REGEX DT_RNDM\.f)
 list(FILTER dpmjetIII193_sources EXCLUDE REGEX DT_RNDMST\.f)
 list(FILTER dpmjetIII193_sources EXCLUDE REGEX DT_RNDMTE\.f)
 list(FILTER dpmjetIII193_sources EXCLUDE REGEX PYR\.f)
-list(APPEND dpmjetIII193_sources ${rangen_fpp_source})
 
 
 f2py_add_module(_dpmjetIII193
@@ -563,11 +477,12 @@ f2py_add_module(_dpmjetIII193
   # ${f2py_dir}/_dpmjetIII193module.c
   # ${f2py_dir}/_dpmjetIII193-f2pywrappers.f
   ${dpmjetIII193_sources}
+  ${rangen_source}
   INCLUDE_DIRS
   ${fortran_dir}/dpmjetIII-19.3/include/phojet
   ${fortran_dir}/dpmjetIII-19.3/include/dpmjet
   ${fortran_dir}/dpmjetIII-19.3/include/pythia
   ${fortran_dir}/dpmjetIII-19.3/include/flinclude
   COMPILE_DEFS
-  IMPY
+  ${impy_definitions}
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -192,15 +192,15 @@ f2py_add_module(_eposlhc
 set(SIBYLL_COMMON_FUNCTIONS
   sibyll sibyll_ini sib_sigma_hp sib_sigma_hair sib_sigma_hnuc
   int_nuc decsib decpar sibini sib_list isib_pid2pdg
-  isib_pdg2pid pdg_ini ${impy_logging})
+  isib_pdg2pid pdg_ini init_rmmard ${impy_logging})
 
 f2py_add_module(_sib21
   FUNCTIONS
   ${SIBYLL_COMMON_FUNCTIONS} sibhep1
   SOURCES
-  ${f2py_dir}/_sib21.pyf
-  ${f2py_dir}/_sib21module.c
-  ${f2py_dir}/_sib21-f2pywrappers.f
+  # ${f2py_dir}/_sib21.pyf
+  # ${f2py_dir}/_sib21module.c
+  # ${f2py_dir}/_sib21-f2pywrappers.f
   ${fortran_dir}/sibyll/sibyll_21.f
   ${fortran_dir}/sibyll/sib21aux.f
   ${logging_source}
@@ -213,9 +213,9 @@ f2py_add_module(_sib23
   FUNCTIONS
   ${SIBYLL_COMMON_FUNCTIONS} sibhep3
   SOURCES
-  ${f2py_dir}/_sib23.pyf
-  ${f2py_dir}/_sib23module.c
-  ${f2py_dir}/_sib23-f2pywrappers.f
+  # ${f2py_dir}/_sib23.pyf
+  # ${f2py_dir}/_sib23module.c
+  # ${f2py_dir}/_sib23-f2pywrappers.f
   ${fortran_dir}/sibyll/sibyll2.3.f
   ${sibyll_init_source}
   ${logging_source}
@@ -227,9 +227,9 @@ f2py_add_module(_sib23c00
   FUNCTIONS
   ${SIBYLL_COMMON_FUNCTIONS} sibhep3
   SOURCES
-  ${f2py_dir}/_sib23c00.pyf
-  ${f2py_dir}/_sib23c00module.c
-  ${f2py_dir}/_sib23c00-f2pywrappers.f
+  # ${f2py_dir}/_sib23c00.pyf
+  # ${f2py_dir}/_sib23c00module.c
+  # ${f2py_dir}/_sib23c00-f2pywrappers.f
   ${fortran_dir}/sibyll/sibyll2.3c00.f
   ${sibyll_init_source}
   ${logging_source}
@@ -241,9 +241,9 @@ f2py_add_module(_sib23c01
   FUNCTIONS
   ${SIBYLL_COMMON_FUNCTIONS} sibhep3
   SOURCES
-  ${f2py_dir}/_sib23c01.pyf
-  ${f2py_dir}/_sib23c01module.c
-  ${f2py_dir}/_sib23c01-f2pywrappers.f
+  # ${f2py_dir}/_sib23c01.pyf
+  # ${f2py_dir}/_sib23c01module.c
+  # ${f2py_dir}/_sib23c01-f2pywrappers.f
   ${fortran_dir}/sibyll/sibyll2.3c01.f
   ${sibyll_init_source}
   ${logging_source}
@@ -255,9 +255,9 @@ f2py_add_module(_sib23c02
   FUNCTIONS
   ${SIBYLL_COMMON_FUNCTIONS} sibhep3
   SOURCES
-  ${f2py_dir}/_sib23c02.pyf
-  ${f2py_dir}/_sib23c02module.c
-  ${f2py_dir}/_sib23c02-f2pywrappers.f
+  # ${f2py_dir}/_sib23c02.pyf
+  # ${f2py_dir}/_sib23c02module.c
+  # ${f2py_dir}/_sib23c02-f2pywrappers.f
   ${fortran_dir}/sibyll/sibyll2.3c02.f
   ${sibyll_init_source}
   ${logging_source}
@@ -269,9 +269,9 @@ f2py_add_module(_sib23c03
   FUNCTIONS
   ${SIBYLL_COMMON_FUNCTIONS} sibhep3
   SOURCES
-  ${f2py_dir}/_sib23c03.pyf
-  ${f2py_dir}/_sib23c03module.c
-  ${f2py_dir}/_sib23c03-f2pywrappers.f
+  # ${f2py_dir}/_sib23c03.pyf
+  # ${f2py_dir}/_sib23c03module.c
+  # ${f2py_dir}/_sib23c03-f2pywrappers.f
   ${fortran_dir}/sibyll/sibyll2.3c03.f
   ${sibyll_init_source}
   ${logging_source}
@@ -283,9 +283,9 @@ f2py_add_module(_sib23d
   FUNCTIONS
   ${SIBYLL_COMMON_FUNCTIONS} sibhep3
   SOURCES
-  ${f2py_dir}/_sib23d.pyf
-  ${f2py_dir}/_sib23dmodule.c
-  ${f2py_dir}/_sib23d-f2pywrappers.f
+  # ${f2py_dir}/_sib23d.pyf
+  # ${f2py_dir}/_sib23dmodule.c
+  # ${f2py_dir}/_sib23d-f2pywrappers.f
   ${fortran_dir}/sibyll/sibyll2.3d.f
   ${sibyll_init_source}
   ${logging_source}
@@ -296,7 +296,7 @@ f2py_add_module(_sib23d
 f2py_add_module(_qgs01
   FUNCTIONS
   cqgsini sectnu xxaini psconf xxreg psaini chepevt
-  ${impy_logging}
+  init_rmmard ${impy_logging}
   SOURCES
   # ${f2py_dir}/_qgs01.pyf
   # ${f2py_dir}/_qgs01module.c
@@ -309,15 +309,15 @@ f2py_add_module(_qgs01
 
 ### qgsII03
 set(QGSJETII_COMMON_FUNCTIONS
-  cqgsini qgsect qgini qgconf qgreg chepevt ${impy_logging})
+  cqgsini qgsect qgini qgconf qgreg chepevt init_rmmard ${impy_logging})
 
 f2py_add_module(_qgsII03
   FUNCTIONS
   ${QGSJETII_COMMON_FUNCTIONS}
   SOURCES
-  ${f2py_dir}/_qgsII03.pyf
-  ${f2py_dir}/_qgsII03module.c
-  ${f2py_dir}/_qgsII03-f2pywrappers.f
+  # ${f2py_dir}/_qgsII03.pyf
+  # ${f2py_dir}/_qgsII03module.c
+  # ${f2py_dir}/_qgsII03-f2pywrappers.f
   ${fortran_dir}/qgsjet/qgsjet-II-03.f
   ${fortran_dir}/qgsjet/impy_qgsII.f
   ${logging_source}
@@ -329,9 +329,9 @@ f2py_add_module(_qgsII04
   FUNCTIONS
   ${QGSJETII_COMMON_FUNCTIONS}
   SOURCES
-  ${f2py_dir}/_qgsII04.pyf
-  ${f2py_dir}/_qgsII04module.c
-  ${f2py_dir}/_qgsII04-f2pywrappers.f
+  # ${f2py_dir}/_qgsII04.pyf
+  # ${f2py_dir}/_qgsII04module.c
+  # ${f2py_dir}/_qgsII04-f2pywrappers.f
   ${fortran_dir}/qgsjet/qgsjet-II-04.f
   ${fortran_dir}/qgsjet/impy_qgsII.f
   ${logging_source}
@@ -363,9 +363,9 @@ f2py_add_module(_urqmd34
   loadwtab norm_init output cascinit nucrad urqini partname
   chepevt ptsigtot init_rmmard ${impy_logging}
   SOURCES
-  ${f2py_dir}/_urqmd34.pyf
-  ${f2py_dir}/_urqmd34module.c
-  ${f2py_dir}/_urqmd34-f2pywrappers.f
+  # ${f2py_dir}/_urqmd34.pyf
+  # ${f2py_dir}/_urqmd34module.c
+  # ${f2py_dir}/_urqmd34-f2pywrappers.f
   ${urqmd34_sources}
 )
 # to find terms.mod ?
@@ -412,7 +412,21 @@ f2py_add_module(_sophia
 )
 
 ### dpmjet306
+
+set(dpmjet_dpmjet306f dpmjet3.0-6.f)
+
+add_custom_command(
+  OUTPUT ${dpmjet_dpmjet306f}
+  COMMAND ${CMAKE_Fortran_COMPILER}
+    -E -cpp ${fortran_dir}/dpmjet3.0-6/sources/dpmjet3.0-6.f
+    -o ${dpmjet_dpmjet306f}
+    -DIMPY
+)
+
+
 file(GLOB dpmjet306_sources ${fortran_dir}/dpmjet3.0-6/sources/*.f)
+list(FILTER dpmjet306_sources EXCLUDE REGEX dpmjet3.0-6\.f)
+
 f2py_add_module(_dpmjet306
   FUNCTIONS
   pho_event dt_init dt_kkinc idt_icihad dt_xsglau
@@ -421,13 +435,15 @@ f2py_add_module(_dpmjet306
   pho_setpdf pycomp pho_xsect pho_borncs pho_harmci pho_fitout
   pho_mcini pho_ptcut pytune pho_rregpar pho_sregpar pho_prevnt
   ipho_pdg2id ipho_id2pdg pho_harint pho_harxto pho_harxpt
-  pho_setpcomb dt_phoxs dt_xshn dt_flahad
+  pho_setpcomb dt_phoxs dt_xshn dt_flahad init_rmmard
   ${impy_logging}
   SOURCES
-  ${f2py_dir}/_dpmjet306.pyf
-  ${f2py_dir}/_dpmjet306module.c
-  ${f2py_dir}/_dpmjet306-f2pywrappers.f
+  # ${f2py_dir}/_dpmjet306.pyf
+  # ${f2py_dir}/_dpmjet306module.c
+  # ${f2py_dir}/_dpmjet306-f2pywrappers.f
   ${dpmjet306_sources}
+  ${dpmjet_dpmjet306f}
+  ${rangen_source}
   ${logging_source}
 )
 
@@ -462,12 +478,12 @@ f2py_add_module(_dpmjetIII191
   pho_setpdf pycomp pho_xsect pho_borncs pho_harmci pho_fitout pho_mcini pho_ptcut
   pytune pho_rregpar pho_sregpar pho_prevnt ipho_pdg2id ipho_id2pdg pho_harint
   pho_harxto pho_harxpt pho_setpcomb
-  dt_phoxs dt_xshn dt_flahad dt_title pho_ghhias
+  dt_phoxs dt_xshn dt_flahad dt_title pho_ghhias init_rmmard
   ${impy_logging}
   SOURCES
-  ${f2py_dir}/_dpmjetIII191.pyf
-  ${f2py_dir}/_dpmjetIII191module.c
-  ${f2py_dir}/_dpmjetIII191-f2pywrappers.f
+  # ${f2py_dir}/_dpmjetIII191.pyf
+  # ${f2py_dir}/_dpmjetIII191module.c
+  # ${f2py_dir}/_dpmjetIII191-f2pywrappers.f
   ${dpmjetIII191_modded_sources}
   INCLUDE_DIRS
   ${fortran_dir}/dpmjetIII-19.1/include/phojet
@@ -497,12 +513,12 @@ f2py_add_module(_dpmjetIII193
   pho_setpdf pycomp pho_xsect pho_borncs pho_harmci pho_fitout pho_mcini pho_ptcut
   pytune pho_rregpar pho_sregpar pho_prevnt ipho_pdg2id ipho_id2pdg pho_harint
   pho_harxto pho_harxpt pho_setpcomb
-  dt_phoxs dt_xshn dt_flahad dt_title pho_ghhias dt_getptn
+  dt_phoxs dt_xshn dt_flahad dt_title pho_ghhias dt_getptn init_rmmard
   ${impy_logging}
   SOURCES
-  ${f2py_dir}/_dpmjetIII193.pyf
-  ${f2py_dir}/_dpmjetIII193module.c
-  ${f2py_dir}/_dpmjetIII193-f2pywrappers.f
+  # ${f2py_dir}/_dpmjetIII193.pyf
+  # ${f2py_dir}/_dpmjetIII193module.c
+  # ${f2py_dir}/_dpmjetIII193-f2pywrappers.f
   ${dpmjetIII193_sources}
   INCLUDE_DIRS
   ${fortran_dir}/dpmjetIII-19.3/include/phojet

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,6 +84,7 @@ set(f2py_dir ${CMAKE_SOURCE_DIR}/src/f2py)
 set(impy_logging impy_openlogfile impy_closelogfile)
 set(logging_source ${fortran_dir}/logging.f)
 set(rangen_source rangen.f)
+set(rangen_fpp_source ${fortran_dir}/rangen.fpp)
 set(rangen_sib21_source rangen_sib21.f)
 set(sibyll_init_source sibyll_init.f)
 set(sibyll_init_sib21_source sibyll_init_sib21.f)
@@ -153,7 +154,7 @@ add_custom_command(
 ### eposlhc
 file(GLOB eposlhc_sources ${fortran_dir}/EPOS-LHC/sources/*.f)
 list(FILTER eposlhc_sources EXCLUDE REGEX epos_example\.f)
-list(FILTER eposlhc_sources EXCLUDE REGEX epos-random\.f)
+# list(FILTER eposlhc_sources EXCLUDE REGEX epos-random\.f)
 
 
 add_custom_command(
@@ -175,16 +176,19 @@ f2py_add_module(_eposlhc
   # ${f2py_dir}/_eposlhcmodule.c
   # ${f2py_dir}/_eposlhc-f2pywrappers.f
   ${eposlhc_sources}
-  ${epos_random_source}
   ${logging_source}
   ${rangen_source}
   INTERFACE_SOURCES
   ${fortran_dir}/EPOS-LHC/sources/epos-bas-lhc.f 
   ${fortran_dir}/EPOS-LHC/sources/epos-ids-lhc.f 
   ${fortran_dir}/EPOS-LHC/sources/epos_interface.f
-  ${epos_random_source}
+  ${fortran_dir}/EPOS-LHC/sources/epos-random.f
   ${rangen_source}
   ${logging_source}
+  INCLUDE_DIRS
+  ${fortran_dir}/EPOS-LHC/sources
+  COMPILE_DEFS
+  IMPY
 )
 
 
@@ -206,6 +210,8 @@ f2py_add_module(_sib21
   ${logging_source}
   ${rangen_sib21_source}
   ${sibyll_init_sib21_source}
+  COMPILE_DEFS
+  IMPY
 )
 
 ### sib23
@@ -220,6 +226,8 @@ f2py_add_module(_sib23
   ${sibyll_init_source}
   ${logging_source}
   ${rangen_source}
+  COMPILE_DEFS
+  IMPY
 )
 
 ### sib23c00
@@ -234,6 +242,8 @@ f2py_add_module(_sib23c00
   ${sibyll_init_source}
   ${logging_source}
   ${rangen_source}
+  COMPILE_DEFS
+  IMPY
 )
 
 ### sib23c01
@@ -248,6 +258,8 @@ f2py_add_module(_sib23c01
   ${sibyll_init_source}
   ${logging_source}
   ${rangen_source}
+  COMPILE_DEFS
+  IMPY
 )
 
 ### sib23c02
@@ -262,6 +274,8 @@ f2py_add_module(_sib23c02
   ${sibyll_init_source}
   ${logging_source}
   ${rangen_source}
+  COMPILE_DEFS
+  IMPY
 )
 
 ### sib23c03
@@ -276,6 +290,8 @@ f2py_add_module(_sib23c03
   ${sibyll_init_source}
   ${logging_source}
   ${rangen_source}
+  COMPILE_DEFS
+  IMPY
 )
 
 ### sib23d
@@ -290,6 +306,8 @@ f2py_add_module(_sib23d
   ${sibyll_init_source}
   ${logging_source}
   ${rangen_source}
+  COMPILE_DEFS
+  IMPY
 )
 
 ### qgs01
@@ -305,6 +323,8 @@ f2py_add_module(_qgs01
   ${fortran_dir}/qgsjet/impy_qgs1.f
   ${logging_source}
   ${rangen_source}
+  COMPILE_DEFS
+  IMPY
 )
 
 ### qgsII03
@@ -322,6 +342,8 @@ f2py_add_module(_qgsII03
   ${fortran_dir}/qgsjet/impy_qgsII.f
   ${logging_source}
   ${rangen_source}
+  COMPILE_DEFS
+  IMPY
 )
 
 ### qgsII04
@@ -336,6 +358,8 @@ f2py_add_module(_qgsII04
   ${fortran_dir}/qgsjet/impy_qgsII.f
   ${logging_source}
   ${rangen_source}
+  COMPILE_DEFS
+  IMPY
 )
 
 ### urqmd34
@@ -367,6 +391,8 @@ f2py_add_module(_urqmd34
   # ${f2py_dir}/_urqmd34module.c
   # ${f2py_dir}/_urqmd34-f2pywrappers.f
   ${urqmd34_sources}
+  COMPILE_DEFS
+  IMPY
 )
 # to find terms.mod ?
 target_include_directories(_urqmd34 PRIVATE ${fortran_dir}/urqmd-3.4/sources)
@@ -384,6 +410,8 @@ f2py_add_module(_pythia6
   ${pythia6_pythia6428_source}
   ${logging_source}
   ${rangen_source}
+  COMPILE_DEFS
+  IMPY
 )
 
 ### sophia
@@ -409,6 +437,8 @@ f2py_add_module(_sophia
   ${fortran_dir}/sophia/impy_sophia.f
   ${logging_source}
   ${rangen_source}
+  COMPILE_DEFS
+  IMPY
 )
 
 ### dpmjet306
@@ -445,7 +475,11 @@ f2py_add_module(_dpmjet306
   ${dpmjet_dpmjet306f}
   ${rangen_source}
   ${logging_source}
+  COMPILE_DEFS
+  IMPY
 )
+
+
 
 ### dpmjetIII191
 file(GLOB dpmjetIII191_sources
@@ -470,32 +504,6 @@ execute_process(
   OUTPUT_VARIABLE dpmjetIII191_modded_sources
 )
 
-set(dpmjetIII191_dir dpmjetIII191)
-add_custom_target(${dpmjetIII191_dir} ALL
-    COMMAND ${CMAKE_COMMAND} -E make_directory ${dpmjetIII191_dir})
-
-set(dpmjetIII191_psources)
-foreach(_file ${dpmjetIII191_modded_sources})
-  get_filename_component(barename ${_file} NAME)
-  set(proc_file ${CMAKE_CURRENT_BINARY_DIR}/${dpmjetIII191_dir}/pp${barename})
-  add_custom_command(
-    OUTPUT ${proc_file}
-    COMMAND ${CMAKE_Fortran_COMPILER}
-    -E -cpp ${_file}
-    -o ${proc_file}
-  ) 
-  list(APPEND dpmjetIII191_psources ${proc_file})
-endforeach()
-
-
-
-# set_source_files_properties(
-#   ${dpmjetIII191_modded_sources}
-#   PROPERTIES
-#   Fortran_PREPROCESS True
-# )
-
-
 
 f2py_add_module(_dpmjetIII191
   FUNCTIONS
@@ -512,13 +520,15 @@ f2py_add_module(_dpmjetIII191
   # ${f2py_dir}/_dpmjetIII191module.c
   # ${f2py_dir}/_dpmjetIII191-f2pywrappers.f
   # ${dpmjetIII191_modded_sources}
-  ${dpmjetIII191_psources}
-  ${rangen_source}
+  ${dpmjetIII191_modded_sources}
+  ${rangen_fpp_source}
   INCLUDE_DIRS
   ${fortran_dir}/dpmjetIII-19.1/include/phojet
   ${fortran_dir}/dpmjetIII-19.1/include/dpmjet
   ${fortran_dir}/dpmjetIII-19.1/include/pythia
   ${CMAKE_CURRENT_BINARY_DIR}/include
+  COMPILE_DEFS
+  IMPY
 )
 
 ### dpmjetIII193
@@ -533,31 +543,8 @@ list(FILTER dpmjetIII193_sources EXCLUDE REGEX DT_RNDM\.f)
 list(FILTER dpmjetIII193_sources EXCLUDE REGEX DT_RNDMST\.f)
 list(FILTER dpmjetIII193_sources EXCLUDE REGEX DT_RNDMTE\.f)
 list(FILTER dpmjetIII193_sources EXCLUDE REGEX PYR\.f)
+list(APPEND dpmjetIII193_sources ${rangen_fpp_source})
 
-# sources need preprocessing
-set(dpmjetIII193_psources)
-set(dpmjetIII193_dir dpmjetIII193)
-add_custom_target(${dpmjetIII193_dir} ALL
-    COMMAND ${CMAKE_COMMAND} -E make_directory ${dpmjetIII193_dir})
-
-foreach(_file ${dpmjetIII193_sources})
-  get_filename_component(barename ${_file} NAME)
-  set(proc_file ${CMAKE_BINARY_DIR}/${dpmjetIII193_dir}/pp${barename})
-  add_custom_command(
-    OUTPUT ${proc_file}
-    COMMAND ${CMAKE_Fortran_COMPILER}
-    -E -cpp ${_file}
-    -o ${proc_file}
-  ) 
-  list(APPEND dpmjetIII193_psources ${proc_file})
-endforeach()
-
-
-# set_source_files_properties(
-#   ${dpmjetIII193_sources}
-#   PROPERTIES
-#   Fortran_PREPROCESS True
-# )
 
 f2py_add_module(_dpmjetIII193
   FUNCTIONS
@@ -569,15 +556,18 @@ f2py_add_module(_dpmjetIII193
   pho_harxto pho_harxpt pho_setpcomb
   dt_phoxs dt_xshn dt_flahad dt_title pho_ghhias dt_getptn init_rmmard
   ${impy_logging}
+  # INTERFACE_SOURCES
+  # ${dpmjetIII193_interface_sources}
   SOURCES
   # ${f2py_dir}/_dpmjetIII193.pyf
   # ${f2py_dir}/_dpmjetIII193module.c
   # ${f2py_dir}/_dpmjetIII193-f2pywrappers.f
-  ${dpmjetIII193_psources}
-  ${rangen_source}
+  ${dpmjetIII193_sources}
   INCLUDE_DIRS
   ${fortran_dir}/dpmjetIII-19.3/include/phojet
   ${fortran_dir}/dpmjetIII-19.3/include/dpmjet
   ${fortran_dir}/dpmjetIII-19.3/include/pythia
   ${fortran_dir}/dpmjetIII-19.3/include/flinclude
+  COMPILE_DEFS
+  IMPY
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,10 @@ if (NOT F2PY_INCLUDE_DIR)
   set(F2PY_INCLUDE_DIR "${_f2py_directory}/src" CACHE STRING "F2PY source directory location" FORCE)
 endif()
 
+# Copy fortranobject.c to get rid of deep folder nesting
+configure_file(${F2PY_INCLUDE_DIR}/fortranobject.c f2py/fortranobject.c COPYONLY)
+set(f2py_source f2py/fortranobject.c)
+
 if (NOT NUMPY_INCLUDE_DIRS)
   execute_process(
     COMMAND ${PYTHON_EXECUTABLE} -c "import numpy; print(numpy.get_include())"
@@ -440,8 +444,8 @@ f2py_add_module(_dpmjetIII191
   ${fortran_dir}/dpmjetIII-19.1/include/phojet
   ${fortran_dir}/dpmjetIII-19.1/include/dpmjet
   ${fortran_dir}/dpmjetIII-19.1/include/pythia
-  ${fortran_dir}/dpmjetIII-19.1/include/flinclude
-  # ${CMAKE_CURRENT_BINARY_DIR}/include
+  # ${fortran_dir}/dpmjetIII-19.1/include/flinclude
+  ${CMAKE_CURRENT_BINARY_DIR}/include
   COMPILE_DEFS
   ${impy_definitions}
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -454,6 +454,11 @@ file(GLOB dpmjetIII191_sources
   ${fortran_dir}/dpmjetIII-19.1/src/dpmjet/*.f
   ${fortran_dir}/dpmjetIII-19.1/common/*.f
 )
+
+list(FILTER dpmjetIII191_sources EXCLUDE REGEX DT_RNDM\.f)
+list(FILTER dpmjetIII191_sources EXCLUDE REGEX DT_RNDMST\.f)
+list(FILTER dpmjetIII191_sources EXCLUDE REGEX DT_RNDMTE\.f)
+list(FILTER dpmjetIII191_sources EXCLUDE REGEX PYR\.f)
 # cmake does not like filenames with parantheses, but some Fortran files
 # include those. As a workaround, we generate modified source files and
 # renamed copies of the headers. Not elegant, but works. 🤷‍♂️
@@ -464,12 +469,34 @@ execute_process(
   ${dpmjetIII191_sources}
   OUTPUT_VARIABLE dpmjetIII191_modded_sources
 )
-# sources need preprocessing
-set_source_files_properties(
-  ${dpmjetIII191_modded_sources}
-  PROPERTIES
-  Fortran_PREPROCESS True
-)
+
+set(dpmjetIII191_dir dpmjetIII191)
+add_custom_target(${dpmjetIII191_dir} ALL
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${dpmjetIII191_dir})
+
+set(dpmjetIII191_psources)
+foreach(_file ${dpmjetIII191_modded_sources})
+  get_filename_component(barename ${_file} NAME)
+  set(proc_file ${CMAKE_CURRENT_BINARY_DIR}/${dpmjetIII191_dir}/pp${barename})
+  add_custom_command(
+    OUTPUT ${proc_file}
+    COMMAND ${CMAKE_Fortran_COMPILER}
+    -E -cpp ${_file}
+    -o ${proc_file}
+  ) 
+  list(APPEND dpmjetIII191_psources ${proc_file})
+endforeach()
+
+
+
+# set_source_files_properties(
+#   ${dpmjetIII191_modded_sources}
+#   PROPERTIES
+#   Fortran_PREPROCESS True
+# )
+
+
+
 f2py_add_module(_dpmjetIII191
   FUNCTIONS
   pho_event dt_init dt_kkinc
@@ -484,7 +511,9 @@ f2py_add_module(_dpmjetIII191
   # ${f2py_dir}/_dpmjetIII191.pyf
   # ${f2py_dir}/_dpmjetIII191module.c
   # ${f2py_dir}/_dpmjetIII191-f2pywrappers.f
-  ${dpmjetIII191_modded_sources}
+  # ${dpmjetIII191_modded_sources}
+  ${dpmjetIII191_psources}
+  ${rangen_source}
   INCLUDE_DIRS
   ${fortran_dir}/dpmjetIII-19.1/include/phojet
   ${fortran_dir}/dpmjetIII-19.1/include/dpmjet
@@ -499,12 +528,37 @@ file(GLOB dpmjetIII193_sources
   ${fortran_dir}/dpmjetIII-19.3/src/dpmjet/*.f
   ${fortran_dir}/dpmjetIII-19.3/common/*.f
 )
+
+list(FILTER dpmjetIII193_sources EXCLUDE REGEX DT_RNDM\.f)
+list(FILTER dpmjetIII193_sources EXCLUDE REGEX DT_RNDMST\.f)
+list(FILTER dpmjetIII193_sources EXCLUDE REGEX DT_RNDMTE\.f)
+list(FILTER dpmjetIII193_sources EXCLUDE REGEX PYR\.f)
+
 # sources need preprocessing
-set_source_files_properties(
-  ${dpmjetIII193_sources}
-  PROPERTIES
-  Fortran_PREPROCESS True
-)
+set(dpmjetIII193_psources)
+set(dpmjetIII193_dir dpmjetIII193)
+add_custom_target(${dpmjetIII193_dir} ALL
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${dpmjetIII193_dir})
+
+foreach(_file ${dpmjetIII193_sources})
+  get_filename_component(barename ${_file} NAME)
+  set(proc_file ${CMAKE_BINARY_DIR}/${dpmjetIII193_dir}/pp${barename})
+  add_custom_command(
+    OUTPUT ${proc_file}
+    COMMAND ${CMAKE_Fortran_COMPILER}
+    -E -cpp ${_file}
+    -o ${proc_file}
+  ) 
+  list(APPEND dpmjetIII193_psources ${proc_file})
+endforeach()
+
+
+# set_source_files_properties(
+#   ${dpmjetIII193_sources}
+#   PROPERTIES
+#   Fortran_PREPROCESS True
+# )
+
 f2py_add_module(_dpmjetIII193
   FUNCTIONS
   pho_event dt_init dt_kkinc
@@ -519,7 +573,8 @@ f2py_add_module(_dpmjetIII193
   # ${f2py_dir}/_dpmjetIII193.pyf
   # ${f2py_dir}/_dpmjetIII193module.c
   # ${f2py_dir}/_dpmjetIII193-f2pywrappers.f
-  ${dpmjetIII193_sources}
+  ${dpmjetIII193_psources}
+  ${rangen_source}
   INCLUDE_DIRS
   ${fortran_dir}/dpmjetIII-19.3/include/phojet
   ${fortran_dir}/dpmjetIII-19.3/include/dpmjet

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,6 +88,12 @@ set(rangen_sib21_source rangen_sib21.f)
 set(sibyll_init_source sibyll_init.f)
 set(sibyll_init_sib21_source sibyll_init_sib21.f)
 
+#
+set(sophia_jetset74dp_source jetset74dp.f)
+set(sophia_eventgen_source eventgen.f)
+set(pythia6_pythia6428_source pythia-6.4.28.f)
+set(epos_random_source epos-random.f)
+
 # WARNING this is not platform-independent and needs to be adjusted
 # when new fortran compilers should be supported
 add_custom_command(
@@ -118,22 +124,69 @@ add_custom_command(
     -DSIBYLL_TABLE_LENGTH=49
 )
 
+
+add_custom_command(
+  OUTPUT ${pythia6_pythia6428_source}
+  COMMAND ${CMAKE_Fortran_COMPILER}
+    -E -cpp ${fortran_dir}/pythia6/pythia-6.4.28.f
+    -o ${pythia6_pythia6428_source}
+    -DIMPY
+)
+
+add_custom_command(
+  OUTPUT ${sophia_jetset74dp_source}
+  COMMAND ${CMAKE_Fortran_COMPILER}
+    -E -cpp ${fortran_dir}/sophia/jetset74dp.f
+    -o ${sophia_jetset74dp_source}
+    -DIMPY
+)
+
+add_custom_command(
+  OUTPUT ${sophia_eventgen_source}
+  COMMAND ${CMAKE_Fortran_COMPILER}
+    -E -cpp ${fortran_dir}/sophia/eventgen.f
+    -o ${sophia_eventgen_source}
+    -DIMPY
+)
+
+
 ### eposlhc
 file(GLOB eposlhc_sources ${fortran_dir}/EPOS-LHC/sources/*.f)
 list(FILTER eposlhc_sources EXCLUDE REGEX epos_example\.f)
+list(FILTER eposlhc_sources EXCLUDE REGEX epos-random\.f)
+
+
+add_custom_command(
+  OUTPUT ${epos_random_source}
+  COMMAND ${CMAKE_Fortran_COMPILER}
+    -E -cpp ${fortran_dir}/EPOS-LHC/sources/epos-random.f
+    -o ${epos_random_source}
+    -DIMPY
+  COMMAND cp  ${fortran_dir}/EPOS-LHC/sources/epos.inc epos.inc  
+)
 
 f2py_add_module(_eposlhc
   FUNCTIONS
   aaset ainit aepos afinal hepmcstore
   getcharge idtrafo initializeepos initeposevt
-  setstable setunstable xsection ${impy_logging}
+  setstable setunstable xsection init_rmmard ${impy_logging}
   SOURCES
-  ${f2py_dir}/_eposlhc.pyf
-  ${f2py_dir}/_eposlhcmodule.c
-  ${f2py_dir}/_eposlhc-f2pywrappers.f
+  # ${f2py_dir}/_eposlhc.pyf
+  # ${f2py_dir}/_eposlhcmodule.c
+  # ${f2py_dir}/_eposlhc-f2pywrappers.f
   ${eposlhc_sources}
+  ${epos_random_source}
+  ${logging_source}
+  ${rangen_source}
+  INTERFACE_SOURCES
+  ${fortran_dir}/EPOS-LHC/sources/epos-bas-lhc.f 
+  ${fortran_dir}/EPOS-LHC/sources/epos-ids-lhc.f 
+  ${fortran_dir}/EPOS-LHC/sources/epos_interface.f
+  ${epos_random_source}
+  ${rangen_source}
   ${logging_source}
 )
+
 
 ### sib21
 set(SIBYLL_COMMON_FUNCTIONS
@@ -245,9 +298,9 @@ f2py_add_module(_qgs01
   cqgsini sectnu xxaini psconf xxreg psaini chepevt
   ${impy_logging}
   SOURCES
-  ${f2py_dir}/_qgs01.pyf
-  ${f2py_dir}/_qgs01module.c
-  ${f2py_dir}/_qgs01-f2pywrappers.f
+  # ${f2py_dir}/_qgs01.pyf
+  # ${f2py_dir}/_qgs01module.c
+  # ${f2py_dir}/_qgs01-f2pywrappers.f
   ${fortran_dir}/qgsjet/qgsjet01d.f
   ${fortran_dir}/qgsjet/impy_qgs1.f
   ${logging_source}
@@ -324,10 +377,11 @@ f2py_add_module(_pythia6
   pyinit pyexec pytune pylist pyevnt pyevnw pystat pyedit
   pyhepc pychge pycomp pyk init_rmmard ${impy_logging}
   SOURCES
-  ${f2py_dir}/_pythia6.pyf
-  ${f2py_dir}/_pythia6module.c
-  ${f2py_dir}/_pythia6-f2pywrappers.f
-  ${fortran_dir}/pythia6/pythia-6.4.28.f
+  # ${f2py_dir}/_pythia6.pyf
+  # ${f2py_dir}/_pythia6module.c
+  # ${f2py_dir}/_pythia6-f2pywrappers.f
+  # ${fortran_dir}/pythia6/pythia-6.4.28.f
+  ${pythia6_pythia6428_source}
   ${logging_source}
   ${rangen_source}
 )
@@ -336,7 +390,12 @@ f2py_add_module(_pythia6
 f2py_add_module(_sophia
   FUNCTIONS
   eventgen print_event crossection initial
-  icon_pdg_sib init_rmmard toevt crranma4 ${impy_logging}
+  icon_pdg_sib init_rmmard toevt ${impy_logging}
+  # INTERFACE_SOURCES
+  # ${sophia_eventgen_source}
+  # ${fortran_dir}/sophia/eventgen.f
+  # ${rangen_source}
+  # ${logging_source}
   SOURCES
   # ${f2py_dir}/_sophia.pyf
   # ${f2py_dir}/_sophiamodule.c
@@ -345,7 +404,8 @@ f2py_add_module(_sophia
   ${fortran_dir}/sophia/eventgen.f
   ${fortran_dir}/sophia/sampling.f
   ${fortran_dir}/sophia/inpoutput.f
-  ${fortran_dir}/sophia/jetset74dp.f
+  # ${fortran_dir}/sophia/jetset74dp.f
+  ${sophia_jetset74dp_source}
   ${fortran_dir}/sophia/impy_sophia.f
   ${logging_source}
   ${rangen_source}

--- a/F2Py.cmake
+++ b/F2Py.cmake
@@ -69,6 +69,12 @@ function (f2py_add_module target_name)
   list(FILTER F2PY_ADD_MODULE_GEN_2 INCLUDE REGEX "${target_name}-f2pywrappers.*")
 
   set(F2PY_ADD_MODULE_LOG_FILE ${CMAKE_CURRENT_BINARY_DIR}/${target_name}.log)
+
+  set(F2PY_ADD_MODULE_INC)
+  if (F2PY_ADD_MODULE_INCLUDE_DIRS)
+    STRING(JOIN ":" _joined_dirs ${F2PY_ADD_MODULE_INCLUDE_DIRS})
+    set(F2PY_ADD_MODULE_INC --include-paths ${_joined_dirs})
+  endif()
   
   if (NOT F2PY_ADD_MODULE_PYF_FILE)
     set(F2PY_ADD_MODULE_PYF_FILE ${CMAKE_CURRENT_BINARY_DIR}/${target_name}.pyf)
@@ -82,6 +88,7 @@ function (f2py_add_module target_name)
         -m ${target_name}
         -h ${F2PY_ADD_MODULE_PYF_FILE}
         --overwrite-signature only: ${F2PY_ADD_MODULE_FUNCTIONS} :
+        ${F2PY_ADD_MODULE_INC}
         ${F2PY_ADD_MODULE_INTERFACE_SOURCES}
         >> ${F2PY_ADD_MODULE_LOG_FILE} 2>&1
 
@@ -92,11 +99,6 @@ function (f2py_add_module target_name)
     message(STATUS "f2py_add_module: Use existing ${F2PY_ADD_MODULE_PYF_FILE}")
   endif()
 
-  set(F2PY_ADD_MODULE_INC)
-  if (F2PY_ADD_MODULE_INCLUDE_DIRS)
-    STRING(JOIN ":" _joined_dirs ${F2PY_ADD_MODULE_INCLUDE_DIRS})
-    set(F2PY_ADD_MODULE_INC --include-paths ${_joined_dirs})
-  endif()
 
   if (F2PY_ADD_MODULE_GEN_1 AND F2PY_ADD_MODULE_GEN_2)
     file(APPEND ${F2PY_ADD_MODULE_LOG_FILE} "f2py_add_module: Use existing ${F2PY_ADD_MODULE_GEN_1} ${F2PY_ADD_MODULE_GEN_2}\n")

--- a/F2Py.cmake
+++ b/F2Py.cmake
@@ -77,42 +77,46 @@ function (f2py_add_module target_name)
   endif()
   
   if (NOT F2PY_ADD_MODULE_PYF_FILE)
-    set(F2PY_ADD_MODULE_PYF_FILE ${CMAKE_CURRENT_BINARY_DIR}/${target_name}.pyf)
+    # Set directory name to output generated file *.pyf files
+    # *module.c and *-f2pywrappers.f
+    set(model_out ${CMAKE_CURRENT_BINARY_DIR}/${target_name}_out)
+    # Set directory name to output processed source files
+    # needed to *.pyf file generation
+    set(pyf_sources "CMakeFiles/${target_name}.dir/pyf_sources")
+    
+    set(F2PY_ADD_MODULE_PYF_FILE ${model_out}/${target_name}.pyf)
     file(WRITE ${F2PY_ADD_MODULE_LOG_FILE} "f2py_add_module: Generating ${F2PY_ADD_MODULE_PYF_FILE}\n")
 
+    # Definitions for source files processing
     set(fortran_defs)
     foreach(_def ${F2PY_ADD_MODULE_COMPILE_DEFS})
       STRING(APPEND fortran_defs "-D${_def} ")
     endforeach()
 
+    # Target to make directories
+    set(mkdir_pyf_sources "mkdir${target_name}_pyf")
+    add_custom_target(${mkdir_pyf_sources}
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${pyf_sources}
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${model_out})
+    
+    # Source files processing for *.pyf
     set(processed_files)
-    set(target_dir "CMakeFiles/${target_name}.dir/processed_files")
-
-    add_custom_command(OUTPUT ${target_dir}
-    COMMAND ${CMAKE_COMMAND} -E make_directory ${target_dir})
-
-
     foreach(_file ${F2PY_ADD_MODULE_INTERFACE_SOURCES})
       string(REGEX REPLACE "\.f$" "\.f\.proc" proc_file ${_file})
       string(REGEX REPLACE "\.fpp$" "\.f\.proc"  proc_file ${proc_file})
       get_filename_component(barename ${proc_file} NAME)
-      set(proc_file ${target_dir}/${barename})
+      set(proc_file ${pyf_sources}/${barename})
 
       add_custom_command(
         OUTPUT ${proc_file}
         COMMAND ${CMAKE_Fortran_COMPILER}
         -E -cpp ${_file} ${fortran_defs} -o ${proc_file}
-        DEPENDS ${target_dir}
+        DEPENDS ${mkdir_pyf_sources}
       )
-      # message("${CMAKE_Fortran_COMPILER} -E -cpp ${_file} ${fortran_defs} -o ${proc_file}")
       list(APPEND processed_files ${proc_file})
     endforeach()
 
-
-    # message("fortran_defs = ${fortran_defs}" )
-    # message("Fortran_FLAGS = ${Fortran_FLAGS}" )
-    # message("Fortran_INCLUDES = ${Fortran_INCLUDES}" )
-
+    # *.pyf file generation
     add_custom_command(
       OUTPUT
       ${F2PY_ADD_MODULE_PYF_FILE}
@@ -138,8 +142,8 @@ function (f2py_add_module target_name)
     message(STATUS "f2py_add_module: Use existing ${F2PY_ADD_MODULE_GEN_1}")
     message(STATUS "f2py_add_module: Use existing ${F2PY_ADD_MODULE_GEN_2}")
   else()
-    set(F2PY_ADD_MODULE_GEN_1 ${CMAKE_CURRENT_BINARY_DIR}/${target_name}module.c)
-    set(F2PY_ADD_MODULE_GEN_2 ${CMAKE_CURRENT_BINARY_DIR}/${target_name}-f2pywrappers.f)
+    set(F2PY_ADD_MODULE_GEN_1 ${model_out}/${target_name}module.c)
+    set(F2PY_ADD_MODULE_GEN_2 ${model_out}/${target_name}-f2pywrappers.f)
 
     add_custom_command(
       OUTPUT ${F2PY_ADD_MODULE_GEN_1} ${F2PY_ADD_MODULE_GEN_2}
@@ -148,13 +152,13 @@ function (f2py_add_module target_name)
         ${F2PY_ADD_MODULE_PYF_FILE}
         ${F2PY_ADD_MODULE_INC}
         >> ${F2PY_ADD_MODULE_LOG_FILE} 2>&1
-
+      WORKING_DIRECTORY ${model_out}
       DEPENDS ${F2PY_ADD_MODULE_SOURCES} ${F2PY_ADD_MODULE_PYF_FILE}
     )
   endif()
 
   add_library(${target_name} MODULE
-    ${F2PY_INCLUDE_DIR}/fortranobject.c
+    ${f2py_source}
     ${F2PY_ADD_MODULE_GEN_1}
     ${F2PY_ADD_MODULE_GEN_2}
     ${F2PY_ADD_MODULE_SOURCES}

--- a/src/fortran/EPOS-LHC/sources/epos-random.f
+++ b/src/fortran/EPOS-LHC/sources/epos-random.f
@@ -63,7 +63,11 @@ c Important : to be call before ranfst
 c-----------------------------------------------------------------------
       IMPLICIT NONE
       INTEGER          KSEQ
+#ifndef IMPY      
       PARAMETER        (KSEQ = 2)
+#else
+      PARAMETER        (KSEQ = 8)
+#endif  
       COMMON /CRRANMA3/CD,CINT,CM,TWOM24,TWOM48,MODCNS
       DOUBLE PRECISION CD,CINT,CM,TWOM24,TWOM48
       INTEGER          MODCNS
@@ -97,7 +101,11 @@ c Important : to be call after ranfgt
 c-----------------------------------------------------------------------
       IMPLICIT NONE
       INTEGER          KSEQ
+#ifndef IMPY      
       PARAMETER        (KSEQ = 2)
+#else
+      PARAMETER        (KSEQ = 8)
+#endif            
       COMMON /CRRANMA3/CD,CINT,CM,TWOM24,TWOM48,MODCNS
       DOUBLE PRECISION CD,CINT,CM,TWOM24,TWOM48
       INTEGER          MODCNS
@@ -190,6 +198,8 @@ c iiseed(2) and iiseed(3) defined in aread
       endif
       return
       end
+
+#ifndef IMPY      
 C=======================================================================
       SUBROUTINE RMMARD( RVEC,LENV,ISEQ )
 C-----------------------------------------------------------------------
@@ -389,3 +399,4 @@ C  COMPLETE INITIALIZATION BY SKIPPING (NTOT2*MODCNS+NTOT) RANDOMNUMBERS
       ENDIF
       RETURN
       END
+#endif      

--- a/src/fortran/dpmjet3.0-6/sources/dpmjet3.0-6.f
+++ b/src/fortran/dpmjet3.0-6/sources/dpmjet3.0-6.f
@@ -27087,6 +27087,7 @@ C     WRITE(LOUT,1000) DAT,TIM
       RETURN
       END
 
+#ifndef IMPY      
 ************************************************************************
 *                                                                      *
 *                 7) Random number generator package                   *
@@ -27340,6 +27341,8 @@ C        WRITE(6,1000)
 
       RETURN
       END
+C #endif IMPY
+#endif
 
 *$ CREATE DT_TITLE.FOR
 *COPY DT_TITLE

--- a/src/fortran/pythia6/pythia-6.4.28.f
+++ b/src/fortran/pythia6/pythia-6.4.28.f
@@ -75327,7 +75327,8 @@ C...PYR
 C...Generates random numbers uniformly distributed between
 C...0 and 1, excluding the endpoints.
  
-      FUNCTION XPYR(IDUMMY)
+#ifndef IMPY
+      FUNCTION PYR(IDUMMY)
  
 C...Double precision and integer declarations.
       IMPLICIT DOUBLE PRECISION(A-H, O-Z)
@@ -75485,7 +75486,8 @@ C...Write error.
  
       RETURN
       END
- 
+C #ENDIF IMPY
+#endif
 C*********************************************************************
  
 C...PYROBO

--- a/src/fortran/rangen.fpp
+++ b/src/fortran/rangen.fpp
@@ -389,6 +389,21 @@ C-----------------------------------------------------------------------
       RETURN
       END
 
+      DOUBLE PRECISION FUNCTION RLU()
+
+C-----------------------------------------------------------------------
+C  RLU  RANDOM GENERATOR FOR JETSET
+C-----------------------------------------------------------------------
+
+      IMPLICIT NONE
+
+      DOUBLE PRECISION SIMRND
+
+      RLU = SIMRND()
+
+      RETURN
+      END
+
       SUBROUTINE INIT_RMMARD(ISEEDIN)
 
 C-----------------------------------------------------------------------

--- a/src/fortran/rangen.fpp
+++ b/src/fortran/rangen.fpp
@@ -415,6 +415,14 @@ C-----------------------------------------------------------------------
       
       IMPLICIT NONE
 
+      INTEGER          KSEQ
+      PARAMETER        (KSEQ = 8)
+      DOUBLE PRECISION C(KSEQ),U(97,KSEQ),UNI
+      INTEGER          IJKL(KSEQ),I97(KSEQ),J97(KSEQ),
+     *                 NTOT(KSEQ),NTOT2(KSEQ),JSEQ
+      
+      COMMON /CRRANMA4/C,U,IJKL,I97,J97,NTOT,NTOT2,JSEQ
+
       INTEGER ISEEDIN, ISEED(3), NSEQ, I
       PARAMETER( NSEQ = 2)
 

--- a/src/fortran/rangen.fpp
+++ b/src/fortran/rangen.fpp
@@ -322,7 +322,7 @@ C  PY(THIA) R(ANDOM GENERATOR)
 C
 C  SEE SUBROUT. RMMARD
 C  WE USE HERE A SIMPLIFIED FORM OF RMMARD WITH JSEQ=1, LENV=1.
-C  THIS FUNCTON IS CALLED FROM SIBYLL ROUTINES.
+C  THIS FUNCTON IS CALLED FROM PYTHIA ROUTINES.
 C-----------------------------------------------------------------------
 
       IMPLICIT NONE
@@ -403,6 +403,47 @@ C-----------------------------------------------------------------------
 
       RETURN
       END
+
+      DOUBLE PRECISION FUNCTION DT_RNDM(VDUMMY)
+
+C-----------------------------------------------------------------------
+C  SEE SUBROUT. RMMARD
+C  WE USE HERE A SIMPLIFIED FORM OF RMMARD WITH JSEQ=1, LENV=1.
+C  THIS FUNCTON IS CALLED FROM DPM_JET306 ROUTINES.
+C-----------------------------------------------------------------------
+
+      IMPLICIT NONE
+
+      DOUBLE PRECISION SIMRND, VDUMMY
+
+      DT_RNDM = SIMRND()
+
+      RETURN
+      END
+
+
+       SUBROUTINE DT_RNDMST(NA1,NA2,NA3,NB1)
+C-----------------------------------------------------------------------
+C  THIS IS A DUMMY FUNCTION FOR  DPM_JET306 ROUTINES
+C  THE ORIGINAL VERSION INITIALIZES "DT_RNDM" RANDOM NUMBER GENERATOR
+C  WHICH IS SUBSTITUTED BY "SIMRND" IN IMPY
+C  "SIMRND" IS INITIALIZED VIA "INIT_RMMARD"
+C-----------------------------------------------------------------------
+        INTEGER NA1, NA2, NA3, NB1
+        RETURN
+        END
+      
+      
+        SUBROUTINE DT_RNDMTE(IO)
+C-----------------------------------------------------------------------
+C  THIS IS A DUMMY FUNCTION FOR  DPM_JET306 ROUTINES
+C  THE ORIGINAL VERSION TESTS "DT_RNDM" RANDOM NUMBER GENERATOR
+C  WHICH IS SUBSTITUTED BY "SIMRND" IN IMPY
+C----------------------------------------------------------------------- 
+        INTEGER IO
+        RETURN      
+        END
+
 
       SUBROUTINE INIT_RMMARD(ISEEDIN)
 

--- a/src/fortran/sophia/Makefile
+++ b/src/fortran/sophia/Makefile
@@ -10,7 +10,7 @@ OBJS= $(subst .f,.o,$(SRCS))
 LIB_NAME = sophia
       
 SFUNCS=eventgen print_event crossection initial\
-      icon_pdg_sib init_rmmard toevt crranma4
+      icon_pdg_sib init_rmmard toevt
 
 all:  install
 

--- a/src/fortran/sophia/Makefile
+++ b/src/fortran/sophia/Makefile
@@ -10,7 +10,7 @@ OBJS= $(subst .f,.o,$(SRCS))
 LIB_NAME = sophia
       
 SFUNCS=eventgen print_event crossection initial\
-      icon_pdg_sib init_rmmard toevt
+      icon_pdg_sib init_rmmard toevt crranma4
 
 all:  install
 

--- a/src/fortran/sophia/jetset74dp.f
+++ b/src/fortran/sophia/jetset74dp.f
@@ -6214,7 +6214,7 @@ C...Purpose: to reconstruct an angle from given x and y coordinates.
 C********************************************************************* 
  
 CDECK  ID>, RLU
-      FUNCTION RLU(IDUMMY) 
+      FUNCTION RLUX(IDUMMY) 
       IMPLICIT DOUBLE PRECISION (A-H,O-Z)
  
 C...Purpose: to generate random numbers uniformly distributed between 
@@ -6280,7 +6280,7 @@ C...Update counters. Random number to output.
         MRLU2=MRLU2+1 
         MRLU3=0 
       ENDIF 
-      RLU=RUNI 
+      RLUX=RUNI 
  
       RETURN 
       END 

--- a/src/fortran/sophia/jetset74dp.f
+++ b/src/fortran/sophia/jetset74dp.f
@@ -6210,11 +6210,12 @@ C...Purpose: to reconstruct an angle from given x and y coordinates.
  
       RETURN 
       END 
- 
+
+#ifndef IMPY  
 C********************************************************************* 
  
 CDECK  ID>, RLU
-      FUNCTION RLUX(IDUMMY) 
+      FUNCTION RLU(IDUMMY) 
       IMPLICIT DOUBLE PRECISION (A-H,O-Z)
  
 C...Purpose: to generate random numbers uniformly distributed between 
@@ -6357,7 +6358,8 @@ C...Write error.
  
       RETURN 
       END 
- 
+C #endif IMPY
+#endif
 C********************************************************************* 
  
 CDECK  ID>, LUROBO

--- a/src/impy/common.py
+++ b/src/impy/common.py
@@ -440,21 +440,22 @@ class RMMARDState:
     _big_counter: np.ndarray = None
     _sequence_number: np.ndarray = None
 
-    def record_state(self, generator):
+    def _record_state(self, generator):
         data = generator.crranma4
 
-        self._c_number = np.copy(data.c)
-        self._u_array = np.copy(data.u)
-        self._u_i = np.copy(data.i97)
-        self._u_j = np.copy(data.j97)
-        self._seed = np.copy(data.ijkl)
-        self._counter = np.copy(data.ntot)
-        self._big_counter = np.copy(data.ntot2)
-        self._sequence_number = np.copy(data.jseq)
+        self._c_number = data.c
+        self._u_array = data.u
+        self._u_i = data.i97
+        self._u_j = data.j97
+        self._seed = data.ijkl
+        self._counter = data.ntot
+        self._big_counter = data.ntot2
+        self._sequence_number = data.jseq
         return self
 
-    def restore_state(self, generator):
+    def _restore_state(self, generator):
         data = generator.crranma4
+
         data.c = self._c_number
         data.u = self._u_array
         data.i97 = self._u_i
@@ -470,14 +471,14 @@ class RMMARDState:
             return NotImplemented
 
         return (
-            (self._c_number == other._c_number).all()
-            and (self._u_array == other._u_array).all()
-            and (self._u_i == other._u_i).all()
-            and (self._u_j == other._u_j).all()
-            and (self._seed == other._seed).all()
-            and (self._counter == other._counter).all()
-            and (self._big_counter == other._big_counter).all()
-            and (self._sequence_number == other._sequence_number).all()
+            np.array_equal(self._c_number, other._c_number)
+            and np.array_equal(self._u_array, other._u_array)
+            and np.array_equal(self._u_i, other._u_i)
+            and np.array_equal(self._u_j, other._u_j)
+            and np.array_equal(self._seed, other._seed)
+            and np.array_equal(self._counter, other._counter)
+            and np.array_equal(self._big_counter, other._big_counter)
+            and np.array_equal(self._sequence_number, other._sequence_number)
         )
 
     def copy(self):
@@ -496,6 +497,12 @@ class RMMARDState:
         with open(filename, "rb") as pfile:
             self = pickle.load(pfile)
         return self
+
+    def __getstate__(self):
+        return self.__dict__
+
+    def __setstate__(self, state):
+        self.__dict__ = state
 
     @property
     def sequence(self):
@@ -632,11 +639,11 @@ class MCRun(ABC):
 
     @property
     def rng_state(self):
-        return RMMARDState().record_state(self.lib)
+        return RMMARDState()._record_state(self.lib)
 
     @rng_state.setter
     def rng_state(self, rng_state):
-        rng_state.restore_state(self.lib)
+        rng_state._restore_state(self.lib)
 
     def dump_rng_state_to(self, filename):
         self.rng_state._dump_to_file(filename)

--- a/src/impy/common.py
+++ b/src/impy/common.py
@@ -495,7 +495,7 @@ class RMMARDState:
     def _restore_from_file(self, filename):
         with open(filename, "rb") as pfile:
             self = pickle.load(pfile)
-        return self  
+        return self
 
     @property
     def sequence(self):

--- a/src/impy/models/dpmjetIII.py
+++ b/src/impy/models/dpmjetIII.py
@@ -181,14 +181,15 @@ class DpmjetIIIRun(MCRun):
         self.lib.dt_init(-1, k.plab, k.A1, k.Z1, k.A2, k.Z2, k.p1pdg, iglau=0)
 
         # Set seed of random number generator
-        sseed = str(seed)
-        n1, n2, n3, n4 = (
-            int(sseed[0:2]),
-            int(sseed[2:4]),
-            int(sseed[4:6]),
-            int(sseed[6:]),
-        )
-        self.lib.dt_rndmst(n1, n2, n3, n4)
+        # sseed = str(seed)
+        # n1, n2, n3, n4 = (
+        #     int(sseed[0:2]),
+        #     int(sseed[2:4]),
+        #     int(sseed[4:6]),
+        #     int(sseed[6:]),
+        # )
+        # self.lib.dt_rndmst(n1, n2, n3, n4)
+        self.lib.init_rmmard(int(seed))
 
         if impy_config["user_frame"] == "center-of-mass":
             self.lib.dtflg1.iframe = 2

--- a/src/impy/models/phojet.py
+++ b/src/impy/models/phojet.py
@@ -198,14 +198,15 @@ class PHOJETRun(MCRun):
             )
 
         # Set seed of random number generator
-        sseed = str(seed)
-        n1, n2, n3, n4 = (
-            int(sseed[0:2]),
-            int(sseed[2:4]),
-            int(sseed[4:6]),
-            int(sseed[6:]),
-        )
-        self.lib.dt_rndmst(n1, n2, n3, n4)
+        # sseed = str(seed)
+        # n1, n2, n3, n4 = (
+        #     int(sseed[0:2]),
+        #     int(sseed[2:4]),
+        #     int(sseed[4:6]),
+        #     int(sseed[6:]),
+        # )
+        # self.lib.dt_rndmst(n1, n2, n3, n4)
+        self.lib.init_rmmard(int(seed))
 
         # if self.def_settings:
         #     print self.class_name + \


### PR DESCRIPTION
As it was discussed there is a need for control of random number generator for testing and debug purposes. The required for this basic functions are: view and copy a current state of generator and restore the state from the saved copy. 

The working example/prototype (currently only for Sophia) is following


```python
import impy
from impy.kinematics import FixedTarget
from impy.constants import TeV, GeV
import numpy as np

ekin = FixedTarget(13 * TeV, "photon", "proton")
generator = impy.models.Sophia20(ekin)

# One can get a view (currently it is copy and it will converted to view):
state0 = generator.rng_state
print("Before run = ", state0.counter, state0.seed)
# Or the same
print("Before run = ", generator.rng_state.counter, generator.rng_state.seed)

# Save a state to a variable:
state0 = state0.copy()

counters = []

for event in generator(10):
    # Print the value of counter (how many time the 
    # random number generator has been called so far) after each event
    print("rng calls = ", generator.rng_state.counter)
    counters.append(generator.rng_state.counter)


# One can save the state to file
generator.dump_rng_state_to("rng_state.dat")
# Or to variable
state1 = generator.rng_state.copy()

# Restore the state from variable
generator.rng_state = state0

# And compare to check whether the state is restored: 
i = 0
for event in generator(10):
    assert counters[i] == generator.rng_state.counter, "Not equal"
    i  = i + 1

state2 = generator.rng_state.copy()
# Restore from file
generator.restore_rng_state_from("rng_state.dat")

# And check for equality
if state2 == generator.rng_state:
    print("Equal")
```

I am not really happy with descriptive but still long names for `restore_rng_state_from` and `dump_rng_state_to`. It would be good to find something more concise.