### PR TITLE
Fix to_hepmc3() and HepMC3 IO

### DIFF
--- a/tests/test_hepmc_io.py
+++ b/tests/test_hepmc_io.py
@@ -41,7 +41,7 @@ def test_hepmc_io(Model):
 
     with pyhepmc.open(test_file, "w") as f:
         for event in expected:
-            f.write(event)  # this calls to_hepmc3() implicitly
+            f.write(event)
 
     restored = []
     with pyhepmc.open(test_file) as f:

--- a/tests/test_hepmc_io.py
+++ b/tests/test_hepmc_io.py
@@ -15,7 +15,7 @@ models = get_all_models(im)
 
 
 def run(Model):
-    ekin = CenterOfMass(10 * GeV, 2212, 2212)
+    ekin = CenterOfMass(10 * GeV, "proton", "proton")
     if Model == im.Sophia20:
         ekin = FixedTarget(10 * GeV, "photon", "proton")
     gen = Model(ekin, seed=1)
@@ -35,29 +35,17 @@ def test_hepmc_io(Model):
     test_file = Path(f"{Path(__file__).with_suffix('')}_{Model.__name__}.dat")
 
     xfail_on_ci_if_model_is_incompatible(Model)
-    if Model in (
-        im.Phojet112,
-        im.Phojet191,
-        im.Phojet193,
-        im.UrQMD34,
-        im.DpmjetIII193,
-    ):
-        pytest.xfail("needs investigation whether the problem is in pyhepmc/HepMC3")
 
-    events = run_in_separate_process(run, Model, timeout=60)
+    events = run_in_separate_process(run, Model, timeout=30)
+    expected = [ev.to_hepmc3() for ev in events]
 
-    expected = []
     with pyhepmc.open(test_file, "w") as f:
-        for event in events:
-            f.write(event)
-            expected.append(event.to_hepmc3())
+        for event in expected:
+            f.write(event)  # this calls to_hepmc3() implicitly
 
     restored = []
-    with pyhepmc.open(test_file) as events:
-        for event in events:
-            assert event is not None
-            # Some models (e.g. Sibyll) do not set event.event_number properly
-            # assert event.event_number == ievent
+    with pyhepmc.open(test_file) as f:
+        for event in f:
             restored.append(event)
 
     assert len(restored) == len(expected)

--- a/tests/test_to_hepmc3.py
+++ b/tests/test_to_hepmc3.py
@@ -15,7 +15,7 @@ def make_event(Model):
     return event  # MCEvent is pickeable, but restored as EventData
 
 
-@pytest.mark.parametrize("Model", (im.Sibyll21, im.Pythia6, im.EposLHC))
+@pytest.mark.parametrize("Model", (im.Sibyll21, im.Sibyll23d, im.Pythia6, im.EposLHC))
 def test_to_hepmc3(Model):
     xfail_on_ci_if_model_is_incompatible(Model)
 

--- a/tests/test_to_hepmc3.py
+++ b/tests/test_to_hepmc3.py
@@ -42,7 +42,17 @@ def test_to_hepmc3(Model):
             pa = (pa[0] - 1, pa[0])
         unique_vertices.setdefault(pa, []).append(i)
 
-    # check that vertices have no overlapping parent ranges
+    # check that parent ranges do not exceed particle range;
+    # that's a requirement for a valid particle history
+    nmax = len(event.px)
+    for i, (a, b) in enumerate(unique_vertices):
+        assert a >= 0 or a == -1
+        assert (
+            b <= nmax
+        ), f"vertex {i} has parent range {(a, b)} which exceeds particle record {nmax=}"
+
+    # check that vertices have no overlapping parent ranges;
+    # that's a requirement for a valid particle history
     uv = list(unique_vertices)
     for i, pa in enumerate(unique_vertices):
         for j in range(i):

--- a/tests/test_to_hepmc3.py
+++ b/tests/test_to_hepmc3.py
@@ -49,7 +49,7 @@ def test_to_hepmc3(Model):
         assert a >= 0 or a == -1
         assert (
             b <= nmax
-        ), f"vertex {i} has parent range {(a, b)} which exceeds particle record {nmax=}"
+        ), f"vertex {i} has parent range {(a, b)} which exceeds particle record nmax={nmax}"
 
     # check that vertices have no overlapping parent ranges;
     # that's a requirement for a valid particle history

--- a/tests/test_to_hepmc3.py
+++ b/tests/test_to_hepmc3.py
@@ -36,11 +36,20 @@ def test_to_hepmc3(Model):
         assert pa.shape == (2,)
         if np.all(pa == 0):
             continue
-        pa = (pa[0], pa[1])
+        pa = (pa[0] - 1, pa[1])
         # normalize intervals
         if pa[1] == 0:
-            pa = (pa[0], pa[0])
+            pa = (pa[0] - 1, pa[0])
         unique_vertices.setdefault(pa, []).append(i)
+
+    # check that vertices have no overlapping parent ranges
+    uv = list(unique_vertices)
+    for i, pa in enumerate(unique_vertices):
+        for j in range(i):
+            pa2 = uv[j]
+            assert not (
+                pa[0] <= pa2[0] < pa[1] or pa[0] <= pa2[1] - 1 < pa[1]
+            ), f"vertices {j} and {i} overlap: {pa2}, {pa}"
 
     # not all vertices have locations different from zero,
     # create unique fake vertex locations for testing
@@ -76,11 +85,11 @@ def test_to_hepmc3(Model):
 
     unique_vertices2 = {}
     for v in hev.vertices:
-        pi = [p.id for p in v.particles_in]
+        pi = [p.id - 1 for p in v.particles_in]
         if len(pi) == 1:
-            pa = (pi[0], pi[0])
+            pa = (pi[0], pi[0] + 1)
         else:
-            pa = (min(pi), max(pi))
+            pa = (min(pi), max(pi) + 1)
         children = [p.id - 1 for p in v.particles_out]
         unique_vertices2[pa] = children
 

--- a/tests/test_to_hepmc3.py
+++ b/tests/test_to_hepmc3.py
@@ -36,10 +36,10 @@ def test_to_hepmc3(Model):
         assert pa.shape == (2,)
         if np.all(pa == 0):
             continue
-        pa = (pa[0] - 1, pa[1])
         # normalize intervals
         if pa[1] == 0:
-            pa = (pa[0] - 1, pa[0])
+            pa = (pa[0], pa[0])
+        pa = (pa[0] - 1, pa[1])
         unique_vertices.setdefault(pa, []).append(i)
 
     # check that parent ranges do not exceed particle range;


### PR DESCRIPTION
This patch tries to address the failures in `test_hepmc_io.py`. It expands `test_to_hepmc3.py`, because at least some failures originate from invalid parent records in the HEPEVT, and those are easier to expose in `test_to_hepmc3.py`.